### PR TITLE
server: ensure server responses are actually flushed and sent

### DIFF
--- a/src/linux_server/auth.go
+++ b/src/linux_server/auth.go
@@ -15,6 +15,7 @@ import (
 
 func HandleAuths(ctx context.Context, defaultMaxPacketSize uint64, handlerFunc ssh3.AuthenticatedHandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		defer w.(http.Flusher).Flush()
 		hijacker, ok := w.(http3.Hijacker)
 		if !ok { // should never happen, unless quic-go change their API
 			log.Error().Msgf("failed to hijack")

--- a/src/server.go
+++ b/src/server.go
@@ -139,7 +139,6 @@ func (s *Server) GetHTTPHandlerFunc(ctx context.Context) SSH3Handler {
 			conversationsManager.addConversation(newConv)
 
 			w.WriteHeader(200)
-			w.(http.Flusher).Flush()
 
 			go func() {
 				// TODO: this hijacks the datagrams for the whole quic connection, so the server


### PR DESCRIPTION
Server requests were not flushed making the client wait for too long for a response.