### PR TITLE
enhance version mismatch handling

### DIFF
--- a/src/conversation.go
+++ b/src/conversation.go
@@ -113,10 +113,11 @@ func (c *Conversation) EstablishClientConversation(req *http.Request, roundTripp
 	serverVersion := rsp.Header.Get("Server")
 	major, minor, patch, err := ParseVersion(serverVersion)
 	if err != nil {
-		log.Error().Msgf("Could not parse server version: %s", serverVersion)
-		return InvalidSSHVersion{ versionString: serverVersion }
-	}
-	if major > MAJOR || minor > MINOR {
+		log.Error().Msgf("Could not parse server version: \"%s\"", serverVersion)
+		if rsp.StatusCode == 200 {
+			return InvalidSSHVersion{ versionString: serverVersion }
+		}
+	} else if major > MAJOR || minor > MINOR {
 		log.Warn().Msgf("The server runs a higher SSH version (%d.%d.%d), you may want to consider to update the client (currently %d.%d.%d)",
 						major, minor, patch, MAJOR, MINOR, PATCH)
 	}

--- a/src/server.go
+++ b/src/server.go
@@ -127,19 +127,6 @@ type SSH3Handler = AuthenticatedHandlerFunc
 func (s *Server) GetHTTPHandlerFunc(ctx context.Context) SSH3Handler {
 
 	return func(authenticatedUsername string, newConv *Conversation, w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Server", GetCurrentVersion())
-		major, minor, patch, err := ParseVersion(r.UserAgent())
-		log.Debug().Msgf("received request from User-Agent %s (major %d, minor %d, patch %d)", r.UserAgent(), major, minor, patch)
-		// currently apply strict version rules
-		if err != nil || major != MAJOR || minor != MINOR {
-			w.WriteHeader(http.StatusForbidden)
-			if err == nil {
-				w.Write([]byte(fmt.Sprintf("Unsupported version: %d.%d.%d not supported by server in version %s", major, minor, patch, GetCurrentVersion())))
-			} else {
-				w.Write([]byte("Unsupported user-agent"))
-			}
-			return
-		}
 		log.Info().Msgf("got request: method: %s, URL: %s", r.Method, r.URL.String())
 		if r.Method == http.MethodConnect && r.Proto == "ssh3" {
 			hijacker, ok := w.(http3.Hijacker)


### PR DESCRIPTION
Ensure that the server provides its version when authentication does not succeed.
Also ensure that the correct error message is displayed in the client when the status code is not 200 when establishing a conversation.