### PR TITLE
draft: fix(util): match non-pointer public key types

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -168,14 +168,14 @@ func JWTSigningMethodFromCryptoPubkey(pubkey crypto.PublicKey) (jwt.SigningMetho
 	log.Debug().Type("SigningMethodType", pubkey).Msg("fetching singing method from crypto.PublicKey")
 
 	switch pubkey.(type) {
-	case rsa.PublicKey, *rsa.PublicKey:
+	case *rsa.PublicKey:
 		log.
 			Trace().
 			Type("SigningMethodType", pubkey).
 			Str("FoundSigningMethod", "RSA").
 			Msg("found public key type")
 		return jwt.SigningMethodRS256, nil
-	case ed25519.PublicKey, *ed25519.PublicKey:
+	case ed25519.PublicKey:
 		log.
 			Trace().
 			Type("SigningMethodType", pubkey).


### PR DESCRIPTION
This PR aims to fix #38. Some `pubkey`s passed to the function are not pointers, but are still valid keys. This commit fixes this bug by adding the non-pointer types to the switch. Furthermore, more debugging log prints are added.

I am submitting this PR as a draft, as integration tests do not pass (see [this comment](https://github.com/francoismichel/ssh3/pull/45#issuecomment-1859118891)).
