### PR TITLE
generate an ed25519 key for testuser

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,8 @@ jobs:
         run: pushd / && sudo sh ${{ github.workspace }}/generate_openssl_selfsigned_certificate.sh && popd
       - name: Generate testuser's SSH key
         run: sudo ssh-keygen -b 4096 -t rsa -f /testuser_id_rsa -q -N ""
+      - name: Generate testuser's ed25519 SSH key
+        run: sudo ssh-keygen -t ed25519 -f /testuser_id_ed25519 -q -N ""
       - name: Generate attacker's SSH key
         run: sudo ssh-keygen -b 4096 -t rsa -f /attacker_id_rsa -q -N ""
       - name: Install Go dependencies
@@ -53,12 +55,12 @@ jobs:
         run: sudo useradd -m ${{matrix.testuser}} && echo "${{matrix.testuser}}:${{matrix.testpasswd}}" | sudo chpasswd
       - name: Create .ssh3 directory
         run: sudo su ${{matrix.testuser}} -c 'mkdir ${{matrix.testuserhome}}/.ssh ${{matrix.testuserhome}}/.ssh3'
-      - name: Put test public key in testuser's authorized_identities
-        run: sudo cp /testuser_id_rsa.pub ${{matrix.testuserhome}}/.ssh3/authorized_identities
+      - name: Put test public keys in testuser's authorized_identities
+        run: cat /testuser_id_rsa.pub /testuser_id_ed25519.pub | sudo tee -a ${{matrix.testuserhome}}/.ssh3/authorized_identities
       - name: Classical unit tests
         run: env CC=${{matrix.archparams.cc}} CGO_ENABLED=1 GOOS=${{matrix.goos}} GOARCH=${{matrix.archparams.goarch}} go run github.com/onsi/ginkgo/v2/ginkgo -r
       - name: Integration tests
-        run: sudo env CERT_PEM=/cert.pem CERT_PRIV_KEY=/priv.key ATTACKER_PRIVKEY=/attacker_id_rsa TESTUSER_PRIVKEY=/testuser_id_rsa TESTUSER_USERNAME=${{matrix.testuser}} CC=${{matrix.archparams.cc}} CGO_ENABLED=1 GOOS=${{matrix.goos}} GOARCH=${{matrix.archparams.goarch}} SSH3_INTEGRATION_TESTS_WITH_SERVER_ENABLED=1 go run github.com/onsi/ginkgo/v2/ginkgo ./integration_tests
+        run: sudo env CERT_PEM=/cert.pem CERT_PRIV_KEY=/priv.key ATTACKER_PRIVKEY=/attacker_id_rsa TESTUSER_PRIVKEY=/testuser_id_rsa TESTUSER_ED25519_PRIVKEY=/testuser_id_ed25519 TESTUSER_USERNAME=${{matrix.testuser}} CC=${{matrix.archparams.cc}} CGO_ENABLED=1 GOOS=${{matrix.goos}} GOARCH=${{matrix.archparams.goarch}} SSH3_INTEGRATION_TESTS_WITH_SERVER_ENABLED=1 go run github.com/onsi/ginkgo/v2/ginkgo ./integration_tests
   build-macos:
     strategy:
       matrix:


### PR DESCRIPTION
The CI build script now generates an ed25519 key pair for testing in integration tests