### PR TITLE
Proper security statements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,7 @@ We are developing SSH3 as an open source project to facilitate community feedbac
 ### 🥷 Do not deploy the SSH3 server on your production servers for now
 Given the current prototype state, we advise *testing SSH3 in sandboxed environments or private networks*. Be aware that making experimental servers directly Internet-accessible could introduce risk before thorough security vetting.
 
-While [hiding](#-your-ssh3-public-server-can-be-hidden) servers behind secret paths has potential benefits, it 
-does not negate the need for rigorous vulnerability analysis before 
-entering production. We are excited by SSH3's future possibilities but 
-encourage additional scrutiny first.
+While [hiding](#-your-ssh3-public-server-can-be-hidden) servers behind secret paths has potential benefits, it does not negate the need for rigorous vulnerability analysis before entering production. We are excited by SSH3's future possibilities but encourage additional scrutiny first.
 
 ## 🥷 Your SSH3 public server can be hidden
 Using SSH3, you can avoid the usual stress of scanning and dictionary attacks against your SSH server. Similarly to your secret Google Drive documents, your SSH3 server can be hidden behind a secret link and only answer to authentication attempts that made an HTTP request to this specific link, like the following:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ While SSH3 shows promise for faster session establishment, it is still at an ear
 We are developing SSH3 as an open source project to facilitate community feedback and analysis. However, we **cannot yet endorse its appropriateness for production systems** without further peer review. Please collaborate with us if you have relevant expertise!
 
 ### 🥷 Do not deploy the SSH3 server on your production servers for now
-
 Given the current prototype state, we advise *testing SSH3 in sandboxed environments or private networks*. Be aware that making experimental servers directly Internet-accessible could introduce risk before thorough security vetting.
 
 While [hiding](#-your-ssh3-public-server-can-be-hidden) servers behind secret paths has potential benefits, it 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Given the current prototype state, we advise *testing SSH3 in sandboxed environm
 
 While [hiding](#-your-ssh3-public-server-can-be-hidden) servers behind secret paths has potential benefits, it 
 does not negate the need for rigorous vulnerability analysis before 
-public launch. We are excited by SSH3's future possibilities but 
+entering production. We are excited by SSH3's future possibilities but 
 encourage additional scrutiny first.
 
 ## 🙏 Community support

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Faster for session establishment, not throughput ! SSH3 offers a significantly f
 <i>SSH3 (top) VS SSHv2 (bottom) session establishement with a 100ms ping towards the server.</i>
 </p>
 
-## ⚡ SSH3 is an experimental prototype
+## ⚡ SSH3 is still experimental
 
 While SSH3 shows promise for faster session establishment, it is 
 still at an early proof-of-concept stage. As with any new complex 
@@ -37,9 +37,9 @@ protocol, **expert cryptographic review over an extended timeframe is required b
 
 We are developing SSH3 as an open source project to facilitate community feedback and analysis. However, we **cannot yet endorse its appropriateness for production systems** without further peer review. Please collaborate with us if you have relevant expertise!
 
-## 🥷 Your SSH3 server should not yet be made public
+## 🥷 Do not deploy the SSH3 server on your production servers for now
 
-Given the current prototype state, we advise **testing SSH3 only on private networks**. Making experimental servers directly Internet-accessible could introduce risk before thorough security vetting.
+Given the current prototype state, we advise *testing SSH3 in sandboxed environments or private networks*. Be aware that making experimental servers directly Internet-accessible could introduce risk before thorough security vetting.
 
 While [hidding](#-your-ssh3-public-server-can-be-hidden) servers behind secret paths has potential benefits, it 
 does not negate the need for rigorous vulnerability analysis before 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,12 @@ Faster for session establishment, not throughput ! SSH3 offers a significantly f
 <i>SSH3 (top) VS SSHv2 (bottom) session establishement with a 100ms ping towards the server.</i>
 </p>
 
-## ⚡ SSH3 is still experimental
+## 🔒 SSH3 security
+While SSHv2 defines its own protocols for user authentication and secure channel establishment, SSH3 relies on the robust and time-tested mechanisms of TLS 1.3, QUIC and HTTP. These protocols are already extensively used to secure security-critical applications on the Internet such as e-commerce and Internet banking.
+
+SSH3 already implements the common password-based and public-key (RSA and EdDSA/ed25519) authentication methods. It also supports new authentication methods such as OAuth 2.0 and allows logging in to your servers using your Google/Microsoft/Github accounts.
+
+### ⚡ SSH3 is still experimental
 
 While SSH3 shows promise for faster session establishment, it is 
 still at an early proof-of-concept stage. As with any new complex 
@@ -37,7 +42,7 @@ protocol, **expert cryptographic review over an extended timeframe is required b
 
 We are developing SSH3 as an open source project to facilitate community feedback and analysis. However, we **cannot yet endorse its appropriateness for production systems** without further peer review. Please collaborate with us if you have relevant expertise!
 
-## 🥷 Do not deploy the SSH3 server on your production servers for now
+### 🥷 Do not deploy the SSH3 server on your production servers for now
 
 Given the current prototype state, we advise *testing SSH3 in sandboxed environments or private networks*. Be aware that making experimental servers directly Internet-accessible could introduce risk before thorough security vetting.
 
@@ -45,26 +50,6 @@ While [hiding](#-your-ssh3-public-server-can-be-hidden) servers behind secret pa
 does not negate the need for rigorous vulnerability analysis before 
 entering production. We are excited by SSH3's future possibilities but 
 encourage additional scrutiny first.
-
-## 🙏 Community support
-
-Help us progress SSH3 responsibly! We welcome capable security 
-researchers to review our codebase and provide feedback. Please also 
-connect us with relevant standards bodies to potentially advance SSH3 
-through the formal IETF/IRTF processes over time.
-
-With collaborative assistance, we hope to iteratively improve SSH3 
-towards safe production readiness. But we cannot credibly make 
-definitive security claims without evidence of extensive expert 
-cryptographic review and adoption by respected security authorities. 
-Let's work together to realize SSH3's possibilities!
-
-## 🔒 SSH3 security
-While SSHv2 defines its own protocols for user authentication and secure channel establishment, SSH3 relies on the robust and time-tested mechanisms of TLS 1.3, QUIC and HTTP. These protocols are already extensively used to secure security-critical applications on the Internet such as e-commerce and Internet banking.
-
-SSH3 already implements the common password-based and public-key (RSA and EdDSA/ed25519) authentication methods.
-It also supports new authentication methods
-such as OAuth 2.0 and allows logging in to your servers using your Google/Microsoft/Github accounts.
 
 ## 🥷 Your SSH3 public server can be hidden
 Using SSH3, you can avoid the usual stress of scanning and dictionary attacks against your SSH server. Similarly to your secret Google Drive documents, your SSH3 server can be hidden behind a secret link and only answer to authentication attempts that made an HTTP request to this specific link, like the following:
@@ -92,6 +77,11 @@ This SSH3 implementation already provides many of the popular features of OpenSS
 - Automatically using the `ssh-agent` for public key authentication
 - SSH agent forwarding to use your local keys on your remote server
 - Direct TCP port forwarding (reverse port forwarding will be implemented in the future)
+
+## 🙏 Community support
+Help us progress SSH3 responsibly! We welcome capable security researchers to review our codebase and provide feedback. Please also connect us with relevant standards bodies to potentially advance SSH3 through the formal IETF/IRTF processes over time.
+
+With collaborative assistance, we hope to iteratively improve SSH3 towards safe production readiness. But we cannot credibly make definitive security claims without evidence of extensive expert cryptographic review and adoption by respected security authorities. Let's work together to realize SSH3's possibilities!
 
 ## Installing SSH3
 You can either download the last [release binaries](https://github.com/francoismichel/ssh3/releases),

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ While SSHv2 defines its own protocols for user authentication and secure channel
 
 SSH3 already implements the common password-based and public-key (RSA and EdDSA/ed25519) authentication methods. It also supports new authentication methods such as OAuth 2.0 and allows logging in to your servers using your Google/Microsoft/Github accounts.
 
-### ⚡ SSH3 is still experimental
+### 🧪 SSH3 is still experimental
 While SSH3 shows promise for faster session establishment, it is still at an early proof-of-concept stage. As with any new complex protocol, **expert cryptographic review over an extended timeframe is required before reasonable security conclusions can be made**.
 
 We are developing SSH3 as an open source project to facilitate community feedback and analysis. However, we **cannot yet endorse its appropriateness for production systems** without further peer review. Please collaborate with us if you have relevant expertise!

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ While SSHv2 defines its own protocols for user authentication and secure channel
 SSH3 already implements the common password-based and public-key (RSA and EdDSA/ed25519) authentication methods. It also supports new authentication methods such as OAuth 2.0 and allows logging in to your servers using your Google/Microsoft/Github accounts.
 
 ### ⚡ SSH3 is still experimental
-
 While SSH3 shows promise for faster session establishment, it is still at an early proof-of-concept stage. As with any new complex protocol, **expert cryptographic review over an extended timeframe is required before reasonable security conclusions can be made**.
 
 We are developing SSH3 as an open source project to facilitate community feedback and analysis. However, we **cannot yet endorse its appropriateness for production systems** without further peer review. Please collaborate with us if you have relevant expertise!

--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ We are developing SSH3 as an open source project to facilitate community feedbac
 
 Given the current prototype state, we advise *testing SSH3 in sandboxed environments or private networks*. Be aware that making experimental servers directly Internet-accessible could introduce risk before thorough security vetting.
 
-While [hidding](#-your-ssh3-public-server-can-be-hidden) servers behind secret paths has potential benefits, it 
+While [hiding](#-your-ssh3-public-server-can-be-hidden) servers behind secret paths has potential benefits, it 
 does not negate the need for rigorous vulnerability analysis before 
 public launch. We are excited by SSH3's future possibilities but 
 encourage additional scrutiny first.
 
-## 🙏 Community support needed
+## 🙏 Community support
 
 Help us progress SSH3 responsibly! We welcome capable security 
 researchers to review our codebase and provide feedback. Please also 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,37 @@ Faster for session establishment, not throughput ! SSH3 offers a significantly f
 <i>SSH3 (top) VS SSHv2 (bottom) session establishement with a 100ms ping towards the server.</i>
 </p>
 
-## 🔒 SSH3 is secure
+## ⚡ SSH3 is an experimental prototype
+
+While SSH3 shows promise for faster session establishment, it is 
+still at an early proof-of-concept stage. As with any new complex 
+protocol, **expert cryptographic review over an extended timeframe is required before reasonable security conclusions can be made**.
+
+We are developing SSH3 as an open source project to facilitate community feedback and analysis. However, we **cannot yet endorse its appropriateness for production systems** without further peer review. Please collaborate with us if you have relevant expertise!
+
+## 🥷 Your SSH3 server should not yet be made public
+
+Given the current prototype state, we advise **testing SSH3 only on private networks**. Making experimental servers directly Internet-accessible could introduce risk before thorough security vetting.
+
+While [hidding](#-your-ssh3-public-server-can-be-hidden) servers behind secret paths has potential benefits, it 
+does not negate the need for rigorous vulnerability analysis before 
+public launch. We are excited by SSH3's future possibilities but 
+encourage additional scrutiny first.
+
+## 🙏 Community support needed
+
+Help us progress SSH3 responsibly! We welcome capable security 
+researchers to review our codebase and provide feedback. Please also 
+connect us with relevant standards bodies to potentially advance SSH3 
+through the formal IETF/IRTF processes over time.
+
+With collaborative assistance, we hope to iteratively improve SSH3 
+towards safe production readiness. But we cannot credibly make 
+definitive security claims without evidence of extensive expert 
+cryptographic review and adoption by respected security authorities. 
+Let's work together to realize SSH3's possibilities!
+
+## 🔒 SSH3 security
 While SSHv2 defines its own protocols for user authentication and secure channel establishment, SSH3 relies on the robust and time-tested mechanisms of TLS 1.3, QUIC and HTTP. These protocols are already extensively used to secure security-critical applications on the Internet such as e-commerce and Internet banking.
 
 SSH3 already implements the common password-based and public-key (RSA and EdDSA/ed25519) authentication methods.

--- a/README.md
+++ b/README.md
@@ -36,9 +36,7 @@ SSH3 already implements the common password-based and public-key (RSA and EdDSA/
 
 ### ⚡ SSH3 is still experimental
 
-While SSH3 shows promise for faster session establishment, it is 
-still at an early proof-of-concept stage. As with any new complex 
-protocol, **expert cryptographic review over an extended timeframe is required before reasonable security conclusions can be made**.
+While SSH3 shows promise for faster session establishment, it is still at an early proof-of-concept stage. As with any new complex protocol, **expert cryptographic review over an extended timeframe is required before reasonable security conclusions can be made**.
 
 We are developing SSH3 as an open source project to facilitate community feedback and analysis. However, we **cannot yet endorse its appropriateness for production systems** without further peer review. Please collaborate with us if you have relevant expertise!
 


### PR DESCRIPTION
This PR proposes adding more measured language around SSH3's current security status. Making absolute security claims about an early prototype could be misleading without extensive analysis and review over time. 

To build community trust and encourage assistance accelerating SSH3's secure development, I've updated the messaging to:

- Note SSH3 is still an experimental proof-of-concept
- Advise against public Internet exposure in present form 
- Explicitly state that expert cryptographic review is still needed
- Call for collaboration to advance the protocol responsibly

I believe positioning SSH3's security more conservatively for now is prudent. It still shows intriguing promise improving on SSH2, but overstating protections too early can risk credibility and user security if vulnerabilities emerge later.

By being upfront about limitations and the need for review, my aim is to facilitate open community engagement accelerating SSH3 towards safe production readiness. I welcome any feedback, and hope these README updates might encourage capable security researchers to help validate and strengthen SSH3 moving forward! 
