### PR TITLE
handle commented and empty lines in authorized_indentities

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,8 +55,12 @@ jobs:
         run: sudo useradd -m ${{matrix.testuser}} && echo "${{matrix.testuser}}:${{matrix.testpasswd}}" | sudo chpasswd
       - name: Create .ssh3 directory
         run: sudo su ${{matrix.testuser}} -c 'mkdir ${{matrix.testuserhome}}/.ssh ${{matrix.testuserhome}}/.ssh3'
+      - name: add the attacker's key as commented in testuser's authorzed identities
+        run: echo "#" $(cat attacker_id_rsa.pub) | sudo tee -a ${{matrix.testuserhome}}/.ssh3/authorized_identities
       - name: Put test public keys in testuser's authorized_identities
         run: cat /testuser_id_rsa.pub /testuser_id_ed25519.pub | sudo tee -a ${{matrix.testuserhome}}/.ssh3/authorized_identities
+      - name: log authorized_identities
+        run: cat ${{matrix.testuserhome}}/.ssh3/authorized_identities
       - name: Classical unit tests
         run: env CC=${{matrix.archparams.cc}} CGO_ENABLED=1 GOOS=${{matrix.goos}} GOARCH=${{matrix.archparams.goarch}} go run github.com/onsi/ginkgo/v2/ginkgo -r
       - name: Integration tests

--- a/linux_server/authorized_identities.go
+++ b/linux_server/authorized_identities.go
@@ -170,8 +170,18 @@ func ParseIdentity(user *linux_util.User, identityStr string) (Identity, error) 
 
 func ParseAuthorizedIdentitiesFile(user *linux_util.User, file *os.File) (identities []Identity, err error) {
 	scanner := bufio.NewScanner(file)
+	lineNumber := 0
 	for scanner.Scan() {
+		lineNumber += 1
 		line := scanner.Text()
+		if len(strings.TrimSpace(line)) == 0 {
+			log.Info().Msgf("%s:%d: skip empty line", file.Name(), lineNumber)
+			continue
+		} else if line[0] == '#' {
+			// commented line
+			log.Info().Msgf("%s:%d: skip commented identity", file.Name(), lineNumber)
+			continue
+		}
 		identity, err := ParseIdentity(user, line)
 		if err == nil {
 			identities = append(identities, identity)


### PR DESCRIPTION
Until now, commented lines raised a logging at error level in authorized_indentities and authorized_keys. (#50) 

We fixed the logging to explicitly say that empty and commented lines are skipped.

Also added a test case with commented lines in authorized_identities

Fixes #50.