### PR TITLE
use fqdn for module

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,10 @@ jobs:
         run: sudo ssh-keygen -b 4096 -t rsa -f /attacker_id_rsa -q -N ""
       - name: Install Go dependencies
         run: go get ./...
+      - name: Fmt code
+        run: |
+          go fmt ./...
+          git diff --exit-code
       - name: Build Client
         run: env CC=${{matrix.archparams.cc}} CGO_ENABLED=1 GOOS=${{matrix.goos}} GOARCH=${{matrix.archparams.goarch}} go build -v cli/client/main.go
       - name: Build Server

--- a/channel.go
+++ b/channel.go
@@ -6,8 +6,9 @@ import (
 	"fmt"
 	"io"
 	"net"
-	ssh3 "ssh3/message"
-	"ssh3/util"
+
+	ssh3 "github.com/francoismichel/ssh3/message"
+	"github.com/francoismichel/ssh3/util"
 
 	"github.com/quic-go/quic-go"
 )
@@ -62,11 +63,11 @@ type channelCloseListener interface {
 }
 
 type ChannelInfo struct {
-	MaxPacketSize  uint64
-	ConversationStreamID uint64 
-	ConversationID ConversationID 
-	ChannelID      uint64
-	ChannelType    string
+	MaxPacketSize        uint64
+	ConversationStreamID uint64
+	ConversationID       ConversationID
+	ChannelID            uint64
+	ChannelType          string
 }
 
 type Channel interface {
@@ -211,7 +212,7 @@ func parseUDPForwardingHeader(channelID uint64, buf util.Reader) (*net.UDPAddr, 
 		return nil, err
 	}
 	return &net.UDPAddr{
-		IP: address,
+		IP:   address,
 		Port: int(port),
 	}, nil
 }
@@ -222,7 +223,7 @@ func parseTCPForwardingHeader(channelID uint64, buf util.Reader) (*net.TCPAddr, 
 		return nil, err
 	}
 	return &net.TCPAddr{
-		IP: address,
+		IP:   address,
 		Port: int(port),
 	}, nil
 }
@@ -236,11 +237,11 @@ func NewChannel(conversationStreamID uint64, conversationID ConversationID, chan
 	}
 	return &channelImpl{
 		ChannelInfo: ChannelInfo{
-			MaxPacketSize:  maxPacketSize,
+			MaxPacketSize:        maxPacketSize,
 			ConversationStreamID: conversationStreamID,
-			ConversationID: conversationID,
-			ChannelID:      channelID,
-			ChannelType:    channelType,
+			ConversationID:       conversationID,
+			ChannelID:            channelID,
+			ChannelType:          channelType,
 		},
 		recv:                 recv,
 		send:                 send,

--- a/cli/client/main.go
+++ b/cli/client/main.go
@@ -29,11 +29,11 @@ import (
 	"golang.org/x/crypto/ssh/agent"
 	"golang.org/x/term"
 
-	"ssh3"
-	"ssh3/auth"
-	"ssh3/cli/client/winsize"
-	ssh3Messages "ssh3/message"
-	"ssh3/util"
+	"github.com/francoismichel/ssh3"
+	"github.com/francoismichel/ssh3/auth"
+	"github.com/francoismichel/ssh3/cli/client/winsize"
+	ssh3Messages "github.com/francoismichel/ssh3/message"
+	"github.com/francoismichel/ssh3/util"
 
 	"github.com/kevinburke/ssh_config"
 	"github.com/quic-go/quic-go"
@@ -50,7 +50,6 @@ func homedir() string {
 		return os.Getenv("HOME")
 	}
 }
-
 
 func forwardAgent(parent context.Context, channel ssh3.Channel) error {
 	sockPath := os.Getenv("SSH_AUTH_SOCK")
@@ -393,7 +392,6 @@ func mainWithStatusCode() int {
 		keyLog = f
 	}
 
-
 	parsedUrl, err := url.Parse(urlFromParam)
 	if err != nil {
 		log.Fatal().Msgf("%s", err)
@@ -460,12 +458,10 @@ func mainWithStatusCode() int {
 	parsedUrl.RawQuery = urlQuery.Encode()
 	requestUrl := parsedUrl.String()
 
-
 	pool, err := x509.SystemCertPool()
 	if err != nil {
 		log.Fatal().Msgf("%s", err)
 	}
-
 
 	tlsConf := &tls.Config{
 		RootCAs:            pool,
@@ -510,7 +506,6 @@ func mainWithStatusCode() int {
 
 	defer roundTripper.Close()
 
-
 	// connect to SSH agent if it exists
 	var agentClient agent.ExtendedAgent
 	var agentKeys []ssh.PublicKey
@@ -533,7 +528,6 @@ func mainWithStatusCode() int {
 		}
 	}
 
-
 	log.Debug().Msgf("dialing QUIC host at %s", fmt.Sprintf("%s:%d", hostname, port))
 
 	if hostnameIsAnIP {
@@ -549,16 +543,16 @@ func mainWithStatusCode() int {
 		tlsConf,
 		&qconf)
 	if err != nil {
-		if transportErr, ok :=  err.(*quic.TransportError); ok {
+		if transportErr, ok := err.(*quic.TransportError); ok {
 			if transportErr.ErrorCode.IsCryptoError() {
 				if tty == nil {
 					log.Error().Msgf("insecure server cert in non-terminal session, aborting")
 					return -1
 				}
 				if _, ok = knownHosts[hostname]; ok {
-					log.Error().Msgf("The server certificate cannot be verified using the one installed in %s. " + 
-									 "If you did not change the server certificate, it could be a machine-in-the-middle attack. "+
-									 "TLS error: %s", knownHostsPath, err)
+					log.Error().Msgf("The server certificate cannot be verified using the one installed in %s. "+
+						"If you did not change the server certificate, it could be a machine-in-the-middle attack. "+
+						"TLS error: %s", knownHostsPath, err)
 					log.Error().Msgf("Aborting.")
 					return -1
 				}
@@ -572,9 +566,9 @@ func mainWithStatusCode() int {
 				}
 
 				_, err := quic.DialAddrEarly(ctx,
-											 fmt.Sprintf("%s:%d", hostname, port),
-											 tlsConf,
-											 &qconf)
+					fmt.Sprintf("%s:%d", hostname, port),
+					tlsConf,
+					&qconf)
 				if !errors.Is(err, certError) {
 					log.Error().Msgf("could not create client QUIC connection: %s", err)
 					return -1
@@ -587,22 +581,22 @@ func mainWithStatusCode() int {
 				// first, carriage return
 				_, _ = tty.WriteString("\r")
 				_, err = tty.WriteString("Received an unknown self-signed certificate from the server.\n\r" +
-										 "We recommend not using self-signed certificates.\n\r" +
-										 "This session is vulnerable a machine-in-the-middle attack.\n\r" + 
-										 "Certificate fingerprint: " +
-										 "SHA256 " + util.Sha256Fingerprint(peerCertificate.Raw) + "\n\r" +
-				 						 "Do you want to add this certificate to ~/.ssh3/known_hosts (yes/no)? ")
+					"We recommend not using self-signed certificates.\n\r" +
+					"This session is vulnerable a machine-in-the-middle attack.\n\r" +
+					"Certificate fingerprint: " +
+					"SHA256 " + util.Sha256Fingerprint(peerCertificate.Raw) + "\n\r" +
+					"Do you want to add this certificate to ~/.ssh3/known_hosts (yes/no)? ")
 				if err != nil {
 					log.Error().Msgf("cound not write on /dev/tty: %s", err)
 					return -1
 				}
-				
+
 				answer := ""
 				reader := bufio.NewReader(tty)
 				for {
 					answer, _ = reader.ReadString('\n')
 					answer = strings.TrimSpace(answer)
-					_, _ = tty.WriteString("\r")	// always ensure a carriage return
+					_, _ = tty.WriteString("\r") // always ensure a carriage return
 					if answer == "yes" || answer == "no" {
 						break
 					}
@@ -648,7 +642,7 @@ func mainWithStatusCode() int {
 	if err != nil {
 		log.Fatal().Msgf("%s", err)
 	}
-	req.Proto = "ssh3"
+	req.Proto = "github.com/francoismichel/ssh3"
 	req.Header.Set("User-Agent", ssh3.GetCurrentVersion())
 
 	var authMethods []interface{}
@@ -658,7 +652,7 @@ func mainWithStatusCode() int {
 		if *privKeyFile != "" {
 			authMethods = append(authMethods, ssh3.NewPrivkeyFileAuthMethod(*privKeyFile))
 		}
-	
+
 		if *pubkeyForAgent != "" {
 			if agentClient == nil {
 				log.Warn().Msgf("specified a public key (%s) but no agent is running", *pubkeyForAgent)
@@ -676,7 +670,7 @@ func mainWithStatusCode() int {
 						return -1
 					}
 				}
-	
+
 				for _, candidateKey := range agentKeys {
 					if pubkey == nil || bytes.Equal(candidateKey.Marshal(), pubkey.Marshal()) {
 						log.Debug().Msgf("found key in agent: %s", candidateKey)
@@ -685,11 +679,11 @@ func mainWithStatusCode() int {
 				}
 			}
 		}
-	
+
 		if *passwordAuthentication {
 			authMethods = append(authMethods, ssh3.NewPasswordAuthMethod())
 		}
-	
+
 	} else {
 		// for now, only perform OIDC if it was explicitly asked by the user
 		if *issuerUrl != "" {

--- a/cli/client/main.go
+++ b/cli/client/main.go
@@ -642,7 +642,7 @@ func mainWithStatusCode() int {
 	if err != nil {
 		log.Fatal().Msgf("%s", err)
 	}
-	req.Proto = "github.com/francoismichel/ssh3"
+	req.Proto = "ssh3"
 	req.Header.Set("User-Agent", ssh3.GetCurrentVersion())
 
 	var authMethods []interface{}

--- a/cli/client/winsize/common.go
+++ b/cli/client/winsize/common.go
@@ -1,4 +1,5 @@
 package winsize
+
 type WindowSize struct {
 	NRows       uint16
 	NCols       uint16

--- a/cli/client/winsize/winsize.go
+++ b/cli/client/winsize/winsize.go
@@ -9,7 +9,7 @@ import (
 
 func GetWinsize() (ws WindowSize, err error) {
 	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(syscall.Stdin), uintptr(syscall.TIOCGWINSZ),
-	uintptr(unsafe.Pointer(&ws)))
+		uintptr(unsafe.Pointer(&ws)))
 	if errno != 0 {
 		err = errno
 	}

--- a/cli/client/winsize/winsize_windows.go
+++ b/cli/client/winsize/winsize_windows.go
@@ -1,11 +1,9 @@
 //go:build windows
+
 package winsize
 
 import "os"
 import "golang.org/x/term"
-
-
-
 
 func GetWinsize() (ws WindowSize, err error) {
 	// for Windows, it is a bit more complicated to get the window size in pixels, so on rely

--- a/cli/server/main.go
+++ b/cli/server/main.go
@@ -28,11 +28,11 @@ import (
 	// "github.com/quic-go/quic-go/logging"
 	// "github.com/quic-go/quic-go/qlog"
 
-	ssh3 "ssh3"
-	"ssh3/linux_server"
-	ssh3Messages "ssh3/message"
-	util "ssh3/util"
-	"ssh3/util/linux_util"
+	ssh3 "github.com/francoismichel/ssh3"
+	"github.com/francoismichel/ssh3/linux_server"
+	ssh3Messages "github.com/francoismichel/ssh3/message"
+	util "github.com/francoismichel/ssh3/util"
+	"github.com/francoismichel/ssh3/util/linux_util"
 )
 
 var signals = map[string]os.Signal{
@@ -107,7 +107,6 @@ func setWinsize(f *os.File, charWidth, charHeight, pixWidth, pixHeight uint64) {
 	syscall.Syscall(syscall.SYS_IOCTL, f.Fd(), uintptr(syscall.TIOCSWINSZ),
 		uintptr(unsafe.Pointer(&struct{ h, w, x, y uint16 }{uint16(charHeight), uint16(charWidth), uint16(pixWidth), uint16(pixHeight)})))
 }
-
 
 // Size is needed by the /demo/upload handler to determine the size of the uploaded file
 type Size interface {
@@ -677,8 +676,8 @@ func main() {
 	verbose := flag.Bool("v", false, "verbose mode, if set")
 	enablePasswordLogin := flag.Bool("enable-password-login", false, "if set, enable password authentication (disabled by default)")
 	urlPath := flag.String("url-path", "/ssh3-term", "the secret URL path on which the ssh3 server listens")
-	generateSelfSignedCert := flag.Bool("generate-selfsigned-cert", false, "if set, generates a self-self-signed cerificate and key " +
-										"that will be stored at the paths indicated by the -cert and -key args (they must not already exist)")
+	generateSelfSignedCert := flag.Bool("generate-selfsigned-cert", false, "if set, generates a self-self-signed cerificate and key "+
+		"that will be stored at the paths indicated by the -cert and -key args (they must not already exist)")
 	certPath := flag.String("cert", "./cert.pem", "the filename of the server certificate (or fullchain)")
 	keyPath := flag.String("key", "./priv.key", "the filename of the certificate private key")
 	flag.Parse()
@@ -699,7 +698,7 @@ func main() {
 		}
 		if !certPathExists || !keyPathExists {
 			fmt.Fprintln(os.Stderr, "If you have no certificate and want a security comparable to traditional SSH host keys, "+
-									 "you can generate a self-signed certificate using the -generate-selfsigned-cert arg or using the following script:")
+				"you can generate a self-signed certificate using the -generate-selfsigned-cert arg or using the following script:")
 			fmt.Fprintln(os.Stderr, "https://github.com/francoismichel/ssh3/blob/main/generate_openssl_selfsigned_certificate.sh")
 			os.Exit(-1)
 		}
@@ -731,7 +730,6 @@ func main() {
 		}
 
 	}
-
 
 	if *verbose {
 		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})

--- a/client.go
+++ b/client.go
@@ -7,11 +7,12 @@ import (
 	"net/http"
 	"os"
 	"path"
-	"ssh3/auth"
-	"ssh3/util"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/francoismichel/ssh3/auth"
+	"github.com/francoismichel/ssh3/util"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/kevinburke/ssh_config"
@@ -20,11 +21,10 @@ import (
 	"golang.org/x/crypto/ssh/agent"
 )
 
-
 type PasswordAuthMethod struct{}
 type OidcAuthMethod struct {
-	doPKCE    bool
-	config    *auth.OIDCConfig
+	doPKCE bool
+	config *auth.OIDCConfig
 }
 
 func (m *OidcAuthMethod) OIDCConfig() *auth.OIDCConfig {
@@ -48,8 +48,8 @@ func (m *PasswordAuthMethod) IntoIdentity(password string) Identity {
 
 func NewOidcAuthMethod(doPKCE bool, config *auth.OIDCConfig) *OidcAuthMethod {
 	return &OidcAuthMethod{
-		doPKCE:    doPKCE,
-		config:    config,
+		doPKCE: doPKCE,
+		config: config,
 	}
 }
 
@@ -82,11 +82,11 @@ func (m *PrivkeyFileAuthMethod) IntoIdentityPassphrase(passphrase string) (Ident
 }
 
 func (m *PrivkeyFileAuthMethod) intoIdentity(passphrase *string) (Identity, error) {
-	
+
 	filename := m.filename
 	if strings.HasPrefix(filename, "~/") {
 		dirname, _ := os.UserHomeDir()
-		filename = path.Join(dirname, filename[2:])	
+		filename = path.Join(dirname, filename[2:])
 	}
 	pemBytes, err := os.ReadFile(filename)
 	if err != nil {
@@ -241,7 +241,6 @@ func (i passwordIdentity) String() string {
 	return "password-identity"
 }
 
-
 type rawBearerTokenIdentity string
 
 func (i rawBearerTokenIdentity) SetAuthorizationHeader(req *http.Request, username string, conversation *Conversation) error {
@@ -299,7 +298,7 @@ func buildJWTBearerToken(signingMethod jwt.SigningMethod, key interface{}, usern
 		"iss":       username,
 		"iat":       jwt.NewNumericDate(time.Now()),
 		"exp":       jwt.NewNumericDate(time.Now().Add(10 * time.Second)),
-		"sub":       "ssh3",
+		"sub":       "github.com/francoismichel/ssh3",
 		"aud":       "unused",
 		"client_id": fmt.Sprintf("ssh3-%s", username),
 		"jti":       b64ConvID,

--- a/client.go
+++ b/client.go
@@ -298,7 +298,7 @@ func buildJWTBearerToken(signingMethod jwt.SigningMethod, key interface{}, usern
 		"iss":       username,
 		"iat":       jwt.NewNumericDate(time.Now()),
 		"exp":       jwt.NewNumericDate(time.Now().Add(10 * time.Second)),
-		"sub":       "github.com/francoismichel/ssh3",
+		"sub":       "ssh3",
 		"aud":       "unused",
 		"client_id": fmt.Sprintf("ssh3-%s", username),
 		"jti":       b64ConvID,

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,9 @@
-module ssh3
+module github.com/francoismichel/ssh3
 
 require (
 	github.com/coreos/go-oidc/v3 v3.7.0
 	github.com/creack/pty v1.1.18
 	github.com/golang-jwt/jwt/v5 v5.0.0
-	github.com/google/go-github/v57 v57.0.0
 	github.com/kevinburke/ssh_config v1.2.0
 	github.com/onsi/ginkgo/v2 v2.13.0
 	github.com/onsi/gomega v1.29.0
@@ -22,7 +21,6 @@ require (
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
-	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,14 +26,9 @@ github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-github/v57 v57.0.0 h1:L+Y3UPTY8ALM8x+TV0lg+IEBI+upibemtBD8Q9u7zHs=
-github.com/google/go-github/v57 v57.0.0/go.mod h1:s0omdnye0hvK/ecLvpsGfJMiRt85PimQh4oygmLIxHw=
-github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
-github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 h1:yAJXTCF9TqKcTiHJAE8dj7HMvPfh66eeA2JYW7eFpSE=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/known_hosts.go
+++ b/known_hosts.go
@@ -28,10 +28,10 @@ func ParseKnownHosts(filename string) (knownHosts map[string][]*x509.Certificate
 	if err != nil {
 		return nil, nil, err
 	}
-    scanner := bufio.NewScanner(file)
+	scanner := bufio.NewScanner(file)
 
-    for i := 0 ; scanner.Scan() ; i++ {
-        knownHost := strings.TrimSpace(scanner.Text())
+	for i := 0; scanner.Scan(); i++ {
+		knownHost := strings.TrimSpace(scanner.Text())
 		fields := strings.Fields(knownHost)
 		if len(fields) != 3 || fields[1] != "x509-certificate" {
 			invalidLines = append(invalidLines, i)
@@ -50,13 +50,13 @@ func ParseKnownHosts(filename string) (knownHosts map[string][]*x509.Certificate
 		certs := knownHosts[fields[0]]
 		certs = append(certs, cert)
 		knownHosts[fields[0]] = certs
-    }
+	}
 	return knownHosts, invalidLines, nil
 }
 
 func AppendKnownHost(filename string, host string, cert *x509.Certificate) error {
 	encodedCert := base64.StdEncoding.EncodeToString(cert.Raw)
-	knownHosts, err := os.OpenFile(filename, os.O_CREATE | syscall.O_APPEND | syscall.O_WRONLY, 0600)
+	knownHosts, err := os.OpenFile(filename, os.O_CREATE|syscall.O_APPEND|syscall.O_WRONLY, 0600)
 	if err != nil {
 		return err
 	}

--- a/linux_server/auth.go
+++ b/linux_server/auth.go
@@ -5,9 +5,10 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
-	"ssh3"
-	"ssh3/util/linux_util"
 	"strings"
+
+	"github.com/francoismichel/ssh3"
+	"github.com/francoismichel/ssh3/util/linux_util"
 
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"

--- a/linux_server/authorized_identities.go
+++ b/linux_server/authorized_identities.go
@@ -54,7 +54,7 @@ func (i *PubKeyIdentity) Verify(genericCandidate interface{}, base64Conversation
 			return nil, fmt.Errorf("unsupported signature algorithm '%s' for %T", unvalidatedToken.Method.Alg(), i)
 		},
 			jwt.WithIssuer(i.username),
-			jwt.WithSubject("github.com/francoismichel/ssh3"),
+			jwt.WithSubject("ssh3"),
 			jwt.WithIssuedAt(),
 			jwt.WithAudience("unused"),
 			jwt.WithValidMethods([]string{"RS256", "EdDSA"}))

--- a/linux_server/authorized_identities.go
+++ b/linux_server/authorized_identities.go
@@ -7,10 +7,11 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"ssh3/auth"
-	"ssh3/util"
-	"ssh3/util/linux_util"
 	"strings"
+
+	"github.com/francoismichel/ssh3/auth"
+	"github.com/francoismichel/ssh3/util"
+	"github.com/francoismichel/ssh3/util/linux_util"
 
 	"github.com/rs/zerolog/log"
 
@@ -53,7 +54,7 @@ func (i *PubKeyIdentity) Verify(genericCandidate interface{}, base64Conversation
 			return nil, fmt.Errorf("unsupported signature algorithm '%s' for %T", unvalidatedToken.Method.Alg(), i)
 		},
 			jwt.WithIssuer(i.username),
-			jwt.WithSubject("ssh3"),
+			jwt.WithSubject("github.com/francoismichel/ssh3"),
 			jwt.WithIssuedAt(),
 			jwt.WithAudience("unused"),
 			jwt.WithValidMethods([]string{"RS256", "EdDSA"}))

--- a/linux_server/handlers.go
+++ b/linux_server/handlers.go
@@ -3,13 +3,13 @@ package linux_server
 import (
 	"net/http"
 	"os"
-	"ssh3"
-	"ssh3/util"
-	"ssh3/util/linux_util"
+
+	"github.com/francoismichel/ssh3"
+	"github.com/francoismichel/ssh3/util"
+	"github.com/francoismichel/ssh3/util/linux_util"
 
 	"github.com/rs/zerolog/log"
 )
-
 
 // BearerAuth returns the bearer token
 // Authorization header, if the request uses HTTP Basic Authentication.

--- a/message/channel_request.go
+++ b/message/channel_request.go
@@ -1,4 +1,4 @@
-package ssh3
+package message
 
 import (
 	"bufio"
@@ -7,7 +7,8 @@ import (
 	"fmt"
 	"io"
 	"net"
-	util "ssh3/util"
+
+	util "github.com/francoismichel/ssh3/util"
 )
 
 var ChannelRequestParseFuncs = map[string]func(util.Reader) (ChannelRequest, error){

--- a/message/message.go
+++ b/message/message.go
@@ -1,43 +1,45 @@
-package ssh3
+package message
 
 import (
 	"errors"
 	"io"
-	"ssh3/util"
+
+	"github.com/francoismichel/ssh3/util"
 )
 
 // ssh messages type
-const SSH_MSG_DISCONNECT                  =     1
-const SSH_MSG_IGNORE                      =     2
-const SSH_MSG_UNIMPLEMENTED               =     3
-const SSH_MSG_DEBUG                       =     4
-const SSH_MSG_SERVICE_REQUEST             =     5
-const SSH_MSG_SERVICE_ACCEPT              =     6
-const SSH_MSG_KEXINIT                     =    20
-const SSH_MSG_NEWKEYS                     =    21
-const SSH_MSG_USERAUTH_REQUEST            =    50
-const SSH_MSG_USERAUTH_FAILURE            =    51
-const SSH_MSG_USERAUTH_SUCCESS            =    52
-const SSH_MSG_USERAUTH_BANNER             =    53
-const SSH_MSG_GLOBAL_REQUEST              =    80
-const SSH_MSG_REQUEST_SUCCESS             =    81
-const SSH_MSG_REQUEST_FAILURE             =    82
-const SSH_MSG_CHANNEL_OPEN                =    90
-const SSH_MSG_CHANNEL_OPEN_CONFIRMATION   =    91
-const SSH_MSG_CHANNEL_OPEN_FAILURE        =    92
-const SSH_MSG_CHANNEL_WINDOW_ADJUST       =    93
-const SSH_MSG_CHANNEL_DATA                =    94
-const SSH_MSG_CHANNEL_EXTENDED_DATA       =    95
-const SSH_MSG_CHANNEL_EOF                 =    96
-const SSH_MSG_CHANNEL_CLOSE               =    97
-const SSH_MSG_CHANNEL_REQUEST             =    98
-const SSH_MSG_CHANNEL_SUCCESS             =    99
-const SSH_MSG_CHANNEL_FAILURE             =   100
+const SSH_MSG_DISCONNECT = 1
+const SSH_MSG_IGNORE = 2
+const SSH_MSG_UNIMPLEMENTED = 3
+const SSH_MSG_DEBUG = 4
+const SSH_MSG_SERVICE_REQUEST = 5
+const SSH_MSG_SERVICE_ACCEPT = 6
+const SSH_MSG_KEXINIT = 20
+const SSH_MSG_NEWKEYS = 21
+const SSH_MSG_USERAUTH_REQUEST = 50
+const SSH_MSG_USERAUTH_FAILURE = 51
+const SSH_MSG_USERAUTH_SUCCESS = 52
+const SSH_MSG_USERAUTH_BANNER = 53
+const SSH_MSG_GLOBAL_REQUEST = 80
+const SSH_MSG_REQUEST_SUCCESS = 81
+const SSH_MSG_REQUEST_FAILURE = 82
+const SSH_MSG_CHANNEL_OPEN = 90
+const SSH_MSG_CHANNEL_OPEN_CONFIRMATION = 91
+const SSH_MSG_CHANNEL_OPEN_FAILURE = 92
+const SSH_MSG_CHANNEL_WINDOW_ADJUST = 93
+const SSH_MSG_CHANNEL_DATA = 94
+const SSH_MSG_CHANNEL_EXTENDED_DATA = 95
+const SSH_MSG_CHANNEL_EOF = 96
+const SSH_MSG_CHANNEL_CLOSE = 97
+const SSH_MSG_CHANNEL_REQUEST = 98
+const SSH_MSG_CHANNEL_SUCCESS = 99
+const SSH_MSG_CHANNEL_FAILURE = 100
 
 type SSHDataType uint64
+
 const (
-	SSH_EXTENDED_DATA_NONE SSHDataType = 0
-    SSH_EXTENDED_DATA_STDERR SSHDataType = 1
+	SSH_EXTENDED_DATA_NONE   SSHDataType = 0
+	SSH_EXTENDED_DATA_STDERR SSHDataType = 1
 )
 
 type Message interface {
@@ -74,11 +76,10 @@ func (m *ChannelOpenConfirmationMessage) Length() int {
 	return int(messageTypeLen) + int(maxPacketSizeLen)
 }
 
-
 type ChannelOpenFailureMessage struct {
-	ReasonCode			 uint64
-	ErrorMessageUTF8     string
-	LanguageTag          string
+	ReasonCode       uint64
+	ErrorMessageUTF8 string
+	LanguageTag      string
 }
 
 var _ Message = &ChannelOpenFailureMessage{}
@@ -98,9 +99,9 @@ func ParseChannelOpenFailureMessage(buf util.Reader) (*ChannelOpenFailureMessage
 		return nil, err
 	}
 	return &ChannelOpenFailureMessage{
-		ReasonCode:		  reasonCode,
-		ErrorMessageUTF8:     errorMessageUTF8,
-		LanguageTag:          languageTag,
+		ReasonCode:       reasonCode,
+		ErrorMessageUTF8: errorMessageUTF8,
+		LanguageTag:      languageTag,
 	}, nil
 }
 
@@ -134,10 +135,9 @@ func (m *ChannelOpenFailureMessage) Write(buf []byte) (consumed int, err error) 
 	return consumed, nil
 }
 
-
 type DataOrExtendedDataMessage struct {
 	DataType SSHDataType
-	Data string
+	Data     string
 }
 
 var _ Message = &DataOrExtendedDataMessage{}
@@ -149,7 +149,7 @@ func ParseDataMessage(buf util.Reader) (*DataOrExtendedDataMessage, error) {
 	}
 	return &DataOrExtendedDataMessage{
 		DataType: SSH_EXTENDED_DATA_NONE,
-		Data: data,
+		Data:     data,
 	}, nil
 }
 
@@ -191,7 +191,7 @@ func ParseExtendedDataMessage(buf util.Reader) (*DataOrExtendedDataMessage, erro
 	}
 	return &DataOrExtendedDataMessage{
 		DataType: SSHDataType(dataType),
-		Data: data,
+		Data:     data,
 	}, err
 }
 
@@ -201,19 +201,19 @@ func ParseMessage(r util.Reader) (Message, error) {
 		return nil, err
 	}
 	switch typeId {
-		case SSH_MSG_CHANNEL_REQUEST:
-			return ParseRequestMessage(r)
-		case SSH_MSG_CHANNEL_OPEN_CONFIRMATION:
-			return ParseChannelOpenConfirmationMessage(r)
-		case SSH_MSG_CHANNEL_OPEN_FAILURE:
-			return ParseChannelOpenFailureMessage(r)
-		case SSH_MSG_CHANNEL_DATA, SSH_MSG_CHANNEL_EXTENDED_DATA:
-			if typeId == SSH_MSG_CHANNEL_DATA {
-				return ParseDataMessage(r)
-			} else {
-				return ParseExtendedDataMessage(r)
-			}
-		default:
-			panic("not implemented")
+	case SSH_MSG_CHANNEL_REQUEST:
+		return ParseRequestMessage(r)
+	case SSH_MSG_CHANNEL_OPEN_CONFIRMATION:
+		return ParseChannelOpenConfirmationMessage(r)
+	case SSH_MSG_CHANNEL_OPEN_FAILURE:
+		return ParseChannelOpenFailureMessage(r)
+	case SSH_MSG_CHANNEL_DATA, SSH_MSG_CHANNEL_EXTENDED_DATA:
+		if typeId == SSH_MSG_CHANNEL_DATA {
+			return ParseDataMessage(r)
+		} else {
+			return ParseExtendedDataMessage(r)
+		}
+	default:
+		panic("not implemented")
 	}
 }

--- a/message/message_suite_test.go
+++ b/message/message_suite_test.go
@@ -1,4 +1,4 @@
-package ssh3_test
+package message
 
 import (
 	"testing"

--- a/message/message_test.go
+++ b/message/message_test.go
@@ -1,11 +1,11 @@
-package ssh3_test
+package message
 
 import (
 	"bytes"
 	"crypto/rand"
 	mathrand "math/rand"
-	ssh3 "ssh3/message"
-	"ssh3/util"
+
+	"github.com/francoismichel/ssh3/util"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -22,7 +22,7 @@ var _ = Describe("Messages", func() {
 	empty_message_data := ""
 	large_message_data := make([]byte, 5000000)
 
-	var small_message, empty_message, large_message *ssh3.DataOrExtendedDataMessage
+	var small_message, empty_message, large_message *DataOrExtendedDataMessage
 	var small_binary_message, empty_binary_message, large_binary_message []byte
 	var small_binary_extended_message, empty_binary_extended_message, large_binary_extended_message []byte
 
@@ -30,15 +30,15 @@ var _ = Describe("Messages", func() {
 		_, err := rand.Read(large_message_data)
 		Expect(err).To(BeNil())
 
-		small_message = &ssh3.DataOrExtendedDataMessage{
+		small_message = &DataOrExtendedDataMessage{
 			DataType: 0,
 			Data:     small_message_data,
 		}
-		empty_message = &ssh3.DataOrExtendedDataMessage{
+		empty_message = &DataOrExtendedDataMessage{
 			DataType: 0,
 			Data:     empty_message_data,
 		}
-		large_message = &ssh3.DataOrExtendedDataMessage{
+		large_message = &DataOrExtendedDataMessage{
 			DataType: 0,
 			Data:     string(large_message_data),
 		}
@@ -76,21 +76,21 @@ var _ = Describe("Messages", func() {
 		Context("Parsing", func() {
 			It("Should parse small data messages", func() {
 				r := bytes.NewReader(small_binary_message)
-				parsed_message, err := ssh3.ParseMessage(&util.BytesReadCloser{Reader: r})
+				parsed_message, err := ParseMessage(&util.BytesReadCloser{Reader: r})
 				Expect(err).To(BeNil())
 				Expect(parsed_message).To(Equal(small_message))
 			})
 
 			It("Should parse empty data messages", func() {
 				r := bytes.NewReader(empty_binary_message)
-				parsed_message, err := ssh3.ParseMessage(&util.BytesReadCloser{Reader: r})
+				parsed_message, err := ParseMessage(&util.BytesReadCloser{Reader: r})
 				Expect(err).To(BeNil())
 				Expect(parsed_message).To(Equal(empty_message))
 			})
 
 			It("Should parse large data messages", func() {
 				r := bytes.NewReader(large_binary_message)
-				parsed_message, err := ssh3.ParseMessage(&util.BytesReadCloser{Reader: r})
+				parsed_message, err := ParseMessage(&util.BytesReadCloser{Reader: r})
 				Expect(err).To(BeNil())
 				Expect(parsed_message).To(Equal(large_message))
 			})
@@ -127,7 +127,7 @@ var _ = Describe("Messages", func() {
 		Context("Parsing", func() {
 			It("Should parse small data messages", func() {
 				r := bytes.NewReader(small_binary_extended_message)
-				parsed_message, err := ssh3.ParseMessage(&util.BytesReadCloser{Reader: r})
+				parsed_message, err := ParseMessage(&util.BytesReadCloser{Reader: r})
 				Expect(err).To(BeNil())
 				small_message.DataType = EXTENDED_DATA_TYPE
 				Expect(parsed_message).To(Equal(small_message))
@@ -135,7 +135,7 @@ var _ = Describe("Messages", func() {
 
 			It("Should parse empty data messages", func() {
 				r := bytes.NewReader(empty_binary_extended_message)
-				parsed_message, err := ssh3.ParseMessage(&util.BytesReadCloser{Reader: r})
+				parsed_message, err := ParseMessage(&util.BytesReadCloser{Reader: r})
 				Expect(err).To(BeNil())
 				empty_message.DataType = EXTENDED_DATA_TYPE
 				Expect(parsed_message).To(Equal(empty_message))
@@ -143,7 +143,7 @@ var _ = Describe("Messages", func() {
 
 			It("Should parse large data messages", func() {
 				r := bytes.NewReader(large_binary_extended_message)
-				parsed_message, err := ssh3.ParseMessage(&util.BytesReadCloser{Reader: r})
+				parsed_message, err := ParseMessage(&util.BytesReadCloser{Reader: r})
 				Expect(err).To(BeNil())
 				large_message.DataType = EXTENDED_DATA_TYPE
 				Expect(parsed_message).To(Equal(large_message))
@@ -213,9 +213,9 @@ var _ = Describe("Messages", func() {
 		pty_req_binary = util.AppendVarInt(pty_req_binary, uint64(len(encodedModes)))
 		pty_req_binary = append(pty_req_binary, encodedModes...)
 
-		pty_req_message := &ssh3.ChannelRequestMessage{
+		pty_req_message := &ChannelRequestMessage{
 			WantReply: wantReply,
-			ChannelRequest: &ssh3.PtyRequest{
+			ChannelRequest: &PtyRequest{
 				Term:                 term,
 				CharWidth:            charWidth,
 				CharHeight:           charHeight,
@@ -242,9 +242,9 @@ var _ = Describe("Messages", func() {
 		x11_req_binary = append(x11_req_binary, x11AuthenticationCookie...)
 		x11_req_binary = util.AppendVarInt(x11_req_binary, uint64(screenNumber))
 
-		x11_req_message := &ssh3.ChannelRequestMessage{
+		x11_req_message := &ChannelRequestMessage{
 			WantReply: wantReply,
-			ChannelRequest: &ssh3.X11Request{
+			ChannelRequest: &X11Request{
 				SingleConnection:          singleConnection,
 				X11AuthenticationProtocol: x11AuthenticationProtocol,
 				X11AuthenticationCookie:   x11AuthenticationCookie,
@@ -258,9 +258,9 @@ var _ = Describe("Messages", func() {
 		shell_req_binary = append(shell_req_binary, "shell"...)
 		shell_req_binary = append(shell_req_binary, wantReplyByte)
 
-		shell_req_message := &ssh3.ChannelRequestMessage{
+		shell_req_message := &ChannelRequestMessage{
 			WantReply:      wantReply,
-			ChannelRequest: &ssh3.ShellRequest{},
+			ChannelRequest: &ShellRequest{},
 		}
 
 		wantReply, wantReplyByte = generateSSHBool()
@@ -272,9 +272,9 @@ var _ = Describe("Messages", func() {
 		exec_req_binary = util.AppendVarInt(exec_req_binary, uint64(len(execCommand)))
 		exec_req_binary = append(exec_req_binary, execCommand...)
 
-		exec_req_message := &ssh3.ChannelRequestMessage{
+		exec_req_message := &ChannelRequestMessage{
 			WantReply: wantReply,
-			ChannelRequest: &ssh3.ExecRequest{
+			ChannelRequest: &ExecRequest{
 				Command: execCommand,
 			},
 		}
@@ -288,9 +288,9 @@ var _ = Describe("Messages", func() {
 		subsystem_req_binary = util.AppendVarInt(subsystem_req_binary, uint64(len(subsystemName)))
 		subsystem_req_binary = append(subsystem_req_binary, execCommand...)
 
-		subsystem_req_message := &ssh3.ChannelRequestMessage{
+		subsystem_req_message := &ChannelRequestMessage{
 			WantReply: wantReply,
-			ChannelRequest: &ssh3.SubsystemRequest{
+			ChannelRequest: &SubsystemRequest{
 				SubsystemName: subsystemName,
 			},
 		}
@@ -305,9 +305,9 @@ var _ = Describe("Messages", func() {
 		window_change_req_binary = util.AppendVarInt(window_change_req_binary, pixelWidth)
 		window_change_req_binary = util.AppendVarInt(window_change_req_binary, pixelHeight)
 
-		window_change_req_message := &ssh3.ChannelRequestMessage{
+		window_change_req_message := &ChannelRequestMessage{
 			WantReply: wantReply,
-			ChannelRequest: &ssh3.WindowChangeRequest{
+			ChannelRequest: &WindowChangeRequest{
 				CharWidth:   charWidth,
 				CharHeight:  charHeight,
 				PixelWidth:  pixelWidth,
@@ -324,9 +324,9 @@ var _ = Describe("Messages", func() {
 		signal_req_binary = util.AppendVarInt(signal_req_binary, uint64(len(sigName)))
 		signal_req_binary = append(signal_req_binary, sigName...)
 
-		signal_req_message := &ssh3.ChannelRequestMessage{
+		signal_req_message := &ChannelRequestMessage{
 			WantReply: wantReply,
-			ChannelRequest: &ssh3.SignalRequest{
+			ChannelRequest: &SignalRequest{
 				SignalNameWithoutSig: sigName,
 			},
 		}
@@ -339,13 +339,12 @@ var _ = Describe("Messages", func() {
 		exit_status_req_binary = append(exit_status_req_binary, wantReplyByte)
 		exit_status_req_binary = util.AppendVarInt(exit_status_req_binary, exitStatus)
 
-		exit_status_req_message := &ssh3.ChannelRequestMessage{
+		exit_status_req_message := &ChannelRequestMessage{
 			WantReply: wantReply,
-			ChannelRequest: &ssh3.ExitStatusRequest{
+			ChannelRequest: &ExitStatusRequest{
 				ExitStatus: exitStatus,
 			},
 		}
-
 
 		wantReply, wantReplyByte = generateSSHBool()
 		signalNameWithoutSig := largeString[:100]
@@ -364,76 +363,76 @@ var _ = Describe("Messages", func() {
 		exit_signal_req_binary = util.AppendVarInt(exit_signal_req_binary, uint64(len(languageTag)))
 		exit_signal_req_binary = append(exit_signal_req_binary, languageTag...)
 
-		exit_signal_req_message := &ssh3.ChannelRequestMessage{
+		exit_signal_req_message := &ChannelRequestMessage{
 			WantReply: wantReply,
-			ChannelRequest: &ssh3.ExitSignalRequest{
+			ChannelRequest: &ExitSignalRequest{
 				SignalNameWithoutSig: signalNameWithoutSig,
-				CoreDumped: coreDumped,
-				ErrorMessageUTF8: errorMessageUTF8,
-				LanguageTag: languageTag,
+				CoreDumped:           coreDumped,
+				ErrorMessageUTF8:     errorMessageUTF8,
+				LanguageTag:          languageTag,
 			},
 		}
 
 		Context("Parsing", func() {
 			It("Parses a pty request", func() {
 				r := bytes.NewReader(pty_req_binary)
-				msg, err := ssh3.ParseMessage(&util.BytesReadCloser{Reader: r})
+				msg, err := ParseMessage(&util.BytesReadCloser{Reader: r})
 				Expect(err).To(BeNil())
 				Expect(msg).To(Equal(pty_req_message))
 			})
 
 			It("Parses an x11 request", func() {
 				r := bytes.NewReader(x11_req_binary)
-				msg, err := ssh3.ParseMessage(&util.BytesReadCloser{Reader: r})
+				msg, err := ParseMessage(&util.BytesReadCloser{Reader: r})
 				Expect(err).To(BeNil())
 				Expect(msg).To(Equal(x11_req_message))
 			})
 
 			It("Parses a shell request", func() {
 				r := bytes.NewReader(shell_req_binary)
-				msg, err := ssh3.ParseMessage(&util.BytesReadCloser{Reader: r})
+				msg, err := ParseMessage(&util.BytesReadCloser{Reader: r})
 				Expect(err).To(BeNil())
 				Expect(msg).To(Equal(shell_req_message))
 			})
 
 			It("Parses an exec request", func() {
 				r := bytes.NewReader(exec_req_binary)
-				msg, err := ssh3.ParseMessage(&util.BytesReadCloser{Reader: r})
+				msg, err := ParseMessage(&util.BytesReadCloser{Reader: r})
 				Expect(err).To(BeNil())
 				Expect(msg).To(Equal(exec_req_message))
 			})
 
 			It("Parses a subsystem request", func() {
 				r := bytes.NewReader(subsystem_req_binary)
-				msg, err := ssh3.ParseMessage(&util.BytesReadCloser{Reader: r})
+				msg, err := ParseMessage(&util.BytesReadCloser{Reader: r})
 				Expect(err).To(BeNil())
 				Expect(msg).To(Equal(subsystem_req_message))
 			})
 
 			It("Parses a window change request", func() {
 				r := bytes.NewReader(window_change_req_binary)
-				msg, err := ssh3.ParseMessage(&util.BytesReadCloser{Reader: r})
+				msg, err := ParseMessage(&util.BytesReadCloser{Reader: r})
 				Expect(err).To(BeNil())
 				Expect(msg).To(Equal(window_change_req_message))
 			})
 
 			It("Parses a signal request", func() {
 				r := bytes.NewReader(signal_req_binary)
-				msg, err := ssh3.ParseMessage(&util.BytesReadCloser{Reader: r})
+				msg, err := ParseMessage(&util.BytesReadCloser{Reader: r})
 				Expect(err).To(BeNil())
 				Expect(msg).To(Equal(signal_req_message))
 			})
 
 			It("Parses an exit status request", func() {
 				r := bytes.NewReader(exit_status_req_binary)
-				msg, err := ssh3.ParseMessage(&util.BytesReadCloser{Reader: r})
+				msg, err := ParseMessage(&util.BytesReadCloser{Reader: r})
 				Expect(err).To(BeNil())
 				Expect(msg).To(Equal(exit_status_req_message))
 			})
 
 			It("Parses an exit signal request", func() {
 				r := bytes.NewReader(exit_signal_req_binary)
-				msg, err := ssh3.ParseMessage(&util.BytesReadCloser{Reader: r})
+				msg, err := ParseMessage(&util.BytesReadCloser{Reader: r})
 				Expect(err).To(BeNil())
 				Expect(msg).To(Equal(exit_signal_req_message))
 			})
@@ -520,13 +519,13 @@ var _ = Describe("Messages", func() {
 		channel_open_confirmation_binary := util.AppendVarInt(nil, CHANNEL_OPEN_CONFIRMATION)
 		channel_open_confirmation_binary = util.AppendVarInt(channel_open_confirmation_binary, maxPacketSize)
 
-		channel_open_confirmation_message := &ssh3.ChannelOpenConfirmationMessage{
+		channel_open_confirmation_message := &ChannelOpenConfirmationMessage{
 			MaxPacketSize: maxPacketSize,
 		}
 		Context("Parsing", func() {
 			It("Should parse a classical message", func() {
 				r := bytes.NewReader(channel_open_confirmation_binary)
-				parsed_message, err := ssh3.ParseMessage(&util.BytesReadCloser{Reader: r})
+				parsed_message, err := ParseMessage(&util.BytesReadCloser{Reader: r})
 				Expect(err).To(BeNil())
 				Expect(parsed_message).To(Equal(channel_open_confirmation_message))
 			})
@@ -558,15 +557,15 @@ var _ = Describe("Messages", func() {
 		channel_open_failure_binary = util.AppendVarInt(channel_open_failure_binary, uint64(len(languageTag)))
 		channel_open_failure_binary = append(channel_open_failure_binary, languageTag...)
 
-		channel_open_failure_message := &ssh3.ChannelOpenFailureMessage{
-			ReasonCode: reasonCode,
+		channel_open_failure_message := &ChannelOpenFailureMessage{
+			ReasonCode:       reasonCode,
 			ErrorMessageUTF8: errorString,
-			LanguageTag: languageTag,
+			LanguageTag:      languageTag,
 		}
 		Context("Parsing", func() {
 			It("Should parse a classical message", func() {
 				r := bytes.NewReader(channel_open_failure_binary)
-				parsed_message, err := ssh3.ParseMessage(&util.BytesReadCloser{Reader: r})
+				parsed_message, err := ParseMessage(&util.BytesReadCloser{Reader: r})
 				Expect(err).To(BeNil())
 				Expect(parsed_message).To(Equal(channel_open_failure_message))
 			})

--- a/resources_manager.go
+++ b/resources_manager.go
@@ -3,20 +3,20 @@ package ssh3
 import (
 	"sync"
 
+	"github.com/francoismichel/ssh3/util"
 	"github.com/quic-go/quic-go/http3"
-	"ssh3/util"
 )
 
 type ControlStreamID = uint64
 
 type conversationsManager struct {
-	connection http3.StreamCreator
+	connection    http3.StreamCreator
 	conversations map[ControlStreamID]*Conversation
-	lock sync.Mutex
+	lock          sync.Mutex
 }
 
 func newConversationManager(connection http3.StreamCreator) *conversationsManager {
-	return &conversationsManager{ connection: connection, conversations: make(map[ControlStreamID]*Conversation)}
+	return &conversationsManager{connection: connection, conversations: make(map[ControlStreamID]*Conversation)}
 }
 
 func (m *conversationsManager) addConversation(conversation *Conversation) {
@@ -32,20 +32,20 @@ func (m *conversationsManager) getConversation(id ControlStreamID) (*Conversatio
 	return conv, ok
 }
 
-func (m * conversationsManager) removeConversation(conversation *Conversation) {
+func (m *conversationsManager) removeConversation(conversation *Conversation) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	delete(m.conversations, uint64(conversation.controlStream.StreamID()))
 }
 
 type channelsManager struct {
-	channels map[util.ChannelID]Channel
+	channels            map[util.ChannelID]Channel
 	danglingDgramQueues map[util.ChannelID]*util.DatagramsQueue
-	lock sync.Mutex
+	lock                sync.Mutex
 }
 
 func newChannelsManager() *channelsManager {
-	return &channelsManager{ channels: make(map[util.ChannelID]Channel), danglingDgramQueues: make(map[util.ChannelID]*util.DatagramsQueue)}
+	return &channelsManager{channels: make(map[util.ChannelID]Channel), danglingDgramQueues: make(map[util.ChannelID]*util.DatagramsQueue)}
 }
 
 func (m *channelsManager) addChannel(channel Channel) {
@@ -64,7 +64,7 @@ func (m *channelsManager) addDanglingDatagramsQueue(id util.ChannelID, queue *ut
 	// let's first check if a channel has recently been added
 	if channel, ok := m.channels[id]; ok {
 		dgram := queue.Next()
-		for ; dgram != nil ; dgram = queue.Next() {
+		for ; dgram != nil; dgram = queue.Next() {
 			channel.addDatagram(dgram)
 		}
 	} else {
@@ -79,7 +79,7 @@ func (m *channelsManager) getChannel(id util.ChannelID) (Channel, bool) {
 	return channel, ok
 }
 
-func (m * channelsManager) removeChannel(channel Channel) {
+func (m *channelsManager) removeChannel(channel Channel) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	delete(m.channels, util.ChannelID(channel.ChannelID()))

--- a/server.go
+++ b/server.go
@@ -13,7 +13,7 @@ import (
 	"github.com/quic-go/quic-go/http3"
 	"github.com/rs/zerolog/log"
 
-	"ssh3/util"
+	"github.com/francoismichel/ssh3/util"
 )
 
 type ServerConversationHandler func(authenticatedUsername string, conversation *Conversation) error
@@ -61,17 +61,17 @@ func NewServer(maxPacketSize uint64, defaultDatagramQueueSize uint64, h3Server *
 		conversation, ok := conversationsManager.getConversation(conversationControlStreamID)
 		if !ok {
 			err := fmt.Errorf("could not find SSH3 conversation with control stream id %d for new channel %d", conversationControlStreamID,
-								uint64(stream.StreamID()))
+				uint64(stream.StreamID()))
 			log.Error().Msgf("%s", err)
 			return false, err
 		}
 
 		channelInfo := &ChannelInfo{
-			ConversationID: conversation.conversationID,
+			ConversationID:       conversation.conversationID,
 			ConversationStreamID: conversationControlStreamID,
-			ChannelID: uint64(stream.StreamID()),
-			ChannelType: channelType,
-			MaxPacketSize: maxPacketSize,
+			ChannelID:            uint64(stream.StreamID()),
+			ChannelType:          channelType,
+			MaxPacketSize:        maxPacketSize,
 		}
 
 		newChannel := NewChannel(channelInfo.ConversationStreamID, channelInfo.ConversationID, uint64(stream.StreamID()), channelInfo.ChannelType, channelInfo.MaxPacketSize, &StreamByteReader{stream},
@@ -130,7 +130,7 @@ func (s *Server) GetHTTPHandlerFunc(ctx context.Context) AuthenticatedHandlerFun
 
 	return func(authenticatedUsername string, newConv *Conversation, w http.ResponseWriter, r *http.Request) {
 		log.Info().Msgf("got request: method: %s, URL: %s", r.Method, r.URL.String())
-		if r.Method == http.MethodConnect && r.Proto == "ssh3" {
+		if r.Method == http.MethodConnect && r.Proto == "github.com/francoismichel/ssh3" {
 			hijacker, ok := w.(http3.Hijacker)
 			if !ok { // should never happen, unless quic-go change their API
 				log.Error().Msg("failed to hijack HTTP conversation: is it an HTTP/3 conversation ?")

--- a/server.go
+++ b/server.go
@@ -130,7 +130,7 @@ func (s *Server) GetHTTPHandlerFunc(ctx context.Context) AuthenticatedHandlerFun
 
 	return func(authenticatedUsername string, newConv *Conversation, w http.ResponseWriter, r *http.Request) {
 		log.Info().Msgf("got request: method: %s, URL: %s", r.Method, r.URL.String())
-		if r.Method == http.MethodConnect && r.Proto == "github.com/francoismichel/ssh3" {
+		if r.Method == http.MethodConnect && r.Proto == "ssh3" {
 			hijacker, ok := w.(http3.Hijacker)
 			if !ok { // should never happen, unless quic-go change their API
 				log.Error().Msg("failed to hijack HTTP conversation: is it an HTTP/3 conversation ?")

--- a/util/linux_util/cmd.go
+++ b/util/linux_util/cmd.go
@@ -1,10 +1,10 @@
 package linux_util
 
 import (
+	ptylib "github.com/creack/pty"
 	"os"
 	"os/exec"
 	"syscall"
-	ptylib "github.com/creack/pty"
 )
 
 // copied and adapted from github.com/creack/pty
@@ -60,4 +60,3 @@ func StartWithSizeAndPty(cmd *exec.Cmd, ws *ptylib.Winsize, pty *os.File, tty *o
 	cmd.SysProcAttr.Setctty = true
 	return StartWithAttrsAndPty(cmd, ws, cmd.SysProcAttr, pty, tty)
 }
-

--- a/util/types.go
+++ b/util/types.go
@@ -49,7 +49,7 @@ func (e InvalidSSHString) Error() string {
 	return fmt.Sprintf("Invalid SSH string: %s", e.Reason)
 }
 
-type Unauthorized struct {}
+type Unauthorized struct{}
 
 func (e Unauthorized) Error() string {
 	return "Unauthorized"

--- a/util/util.go
+++ b/util/util.go
@@ -73,7 +73,6 @@ func ConfigureLogger(logLevel string) {
 	}
 }
 
-
 // Accept queue copied from https://github.com/quic-go/webtransport-go/blob/master/session.go
 type AcceptQueue[T any] struct {
 	mx sync.Mutex
@@ -116,7 +115,6 @@ func (q *AcceptQueue[T]) Next() T {
 
 func (q *AcceptQueue[T]) Chan() <-chan struct{} { return q.c }
 
-
 type DatagramsQueue struct {
 	c chan []byte
 }
@@ -144,7 +142,6 @@ func (q *DatagramsQueue) WaitAdd(ctx context.Context, datagram []byte) error {
 		return context.Cause(ctx)
 	}
 }
-
 
 func (q *DatagramsQueue) Next() []byte {
 	select {
@@ -197,7 +194,6 @@ func Sha256Fingerprint(in []byte) string {
 	return base64.StdEncoding.EncodeToString(hash[:])
 }
 
-
 func getSANExtension(cert *x509.Certificate) []byte {
 	oidExtensionSubjectAltName := []int{2, 5, 29, 17}
 	for _, e := range cert.Extensions {
@@ -207,7 +203,6 @@ func getSANExtension(cert *x509.Certificate) []byte {
 	}
 	return nil
 }
-
 
 func forEachSAN(der cryptobyte.String, callback func(tag int, data []byte) error) error {
 	if !der.ReadASN1(&der, cryptobyte_asn1.SEQUENCE) {
@@ -227,7 +222,6 @@ func forEachSAN(der cryptobyte.String, callback func(tag int, data []byte) error
 	return nil
 }
 
-
 // returns true whether the certificat contains a SubjectAltName extension
 // with at least one IP address record
 func CertHasIPSANs(cert *x509.Certificate) (bool, error) {
@@ -245,7 +239,7 @@ func CertHasIPSANs(cert *x509.Certificate) (bool, error) {
 			case net.IPv4len, net.IPv6len:
 				ipAddresses = append(ipAddresses, data)
 			default:
-				return fmt.Errorf("x509: cannot parse IP address of length %d",len(data))
+				return fmt.Errorf("x509: cannot parse IP address of length %d", len(data))
 			}
 		default:
 		}
@@ -278,8 +272,8 @@ func GenerateCert(priv crypto.PrivateKey) (*x509.Certificate, error) {
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
-		DNSNames: []string{"*", "selfsigned.ssh3"},
-		IsCA: true,
+		DNSNames:              []string{"*", "selfsigned.ssh3"},
+		IsCA:                  true,
 	}
 
 	return &cert, nil
@@ -310,7 +304,7 @@ func DumpCertAndKeyToFiles(cert *x509.Certificate, pubkey crypto.PublicKey, priv
 	if err != nil {
 		return err
 	}
-	err = pem.Encode(keyFile, &pem.Block{ Type: "PRIVATE KEY", Bytes: keyBytes })
+	err = pem.Encode(keyFile, &pem.Block{Type: "PRIVATE KEY", Bytes: keyBytes})
 	if err != nil {
 		return err
 	}

--- a/util/wire.go
+++ b/util/wire.go
@@ -22,7 +22,6 @@ const (
 	maxVarInt8 = 4611686018427387903
 )
 
-
 // Reader implements both the io.ByteReader and io.Reader interfaces.
 type Reader interface {
 	io.ByteReader
@@ -212,7 +211,7 @@ func ParseSSHString(buf Reader) (string, error) {
 	if n != int(length) {
 		return "", InvalidSSHString{fmt.Errorf("expected length %d, read length %d", length, n)}
 	}
-	if err != nil && err != io.EOF{
+	if err != nil && err != io.EOF {
 		return "", err
 	}
 	return string(out[:n]), err

--- a/version.go
+++ b/version.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 )
+
 const MAJOR int = 0
 const MINOR int = 1
 const PATCH int = 3
@@ -35,27 +36,27 @@ func ParseVersion(version string) (major int, minor int, patch int, err error) {
 	fields := strings.Fields(version)
 	if len(fields) != 4 || fields[0] != "SSH" || fields[1] != "3.0" {
 		log.Error().Msgf("bad SSH version fields")
-		return 0, 0, 0, InvalidSSHVersion{ versionString: version }
+		return 0, 0, 0, InvalidSSHVersion{versionString: version}
 	}
 	majorDotMinor := strings.Split(fields[3], ".")
 	if len(majorDotMinor) != 3 {
 		log.Error().Msgf("bad SSH version major.minor.patch field")
-		return 0, 0, 0, InvalidSSHVersion{ versionString: version }
+		return 0, 0, 0, InvalidSSHVersion{versionString: version}
 	}
 	major, err = strconv.Atoi(majorDotMinor[0])
 	if err != nil {
 		log.Error().Msgf("bad SSH version major value")
-		return 0, 0, 0, InvalidSSHVersion{ versionString: version }
+		return 0, 0, 0, InvalidSSHVersion{versionString: version}
 	}
 	minor, err = strconv.Atoi(majorDotMinor[1])
 	if err != nil {
 		log.Error().Msgf("bad SSH version minor value")
-		return 0, 0, 0, InvalidSSHVersion{ versionString: version }
+		return 0, 0, 0, InvalidSSHVersion{versionString: version}
 	}
 	patch, err = strconv.Atoi(majorDotMinor[2])
 	if err != nil {
 		log.Error().Msgf("bad SSH version patch value")
-		return 0, 0, 0, InvalidSSHVersion{ versionString: version }
+		return 0, 0, 0, InvalidSSHVersion{versionString: version}
 	}
 	return major, minor, patch, nil
 }


### PR DESCRIPTION
Used `gofmt` to rename `ssh3` to `github.com/francoismichel/ssh3`. The code hasn't been formatted so this resulted in a lot of whitespace changes.