### PR TITLE
minor issue: fix remotePort validation

### DIFF
--- a/cmd/ssh3/main.go
+++ b/cmd/ssh3/main.go
@@ -222,7 +222,7 @@ func parseAddrPort(addrPort string) (localPort int, remoteIP net.IP, remotePort 
 	remotePort, err = strconv.Atoi(array[1])
 	if err != nil {
 		return 0, nil, 0, fmt.Errorf("could not convert %s to int: %s", array[1], err)
-	} else if localPort > 0xFFFF {
+	} else if remotePort > 0xFFFF {
 		return 0, nil, 0, fmt.Errorf("UDP port too large %d", remotePort)
 	}
 	return localPort, remoteIP, remotePort, err


### PR DESCRIPTION
I ran [govanish](https://github.com/sivukhin/govanish) linter (it still in the WIP phase) against `ssh3` repo and it found a but: compiler eliminated following error check from the binary:
```go
remotePort, err = strconv.Atoi(array[1])
if err != nil {
	return 0, nil, 0, fmt.Errorf("could not convert %s to int: %s", array[1], err)
} else if localPort > 0xFFFF {
	return 0, nil, 0, fmt.Errorf("UDP port too large %d", remotePort)
}
```
```
2023/12/25 19:08:30 it seems like your code vanished from compiled binary: func=[parseAddrPort], file=[/home/sivukhin/code/ssh3/cmd/ssh3/main.go], line=[226], snippet:
	return 0, nil, 0, fmt.Errorf("UDP port too large %d", remotePort)
```
This is a bug, because we need to validation `remotePort` value instead.

This PR fixes this minor issue.