### PR TITLE
Correctly parse user GID

### DIFF
--- a/util/unix_util/non_password_auth_user.go
+++ b/util/unix_util/non_password_auth_user.go
@@ -18,21 +18,21 @@ func getUser(username string) (*User, error) {
 		return nil, err
 	}
 
-	uid, err := strconv.Atoi(u.Uid)
+	uid, err := strconv.ParseUint(u.Uid, 10, 64)
 	if err != nil {
-		log.Error().Msgf("could not convert uid %s into an int")
+		log.Error().Msgf("could not convert uid %s into a uint64", u.Uid)
 		return nil, err
 	}
-	gid, err := strconv.Atoi(u.Uid)
+	gid, err := strconv.ParseUint(u.Gid, 10, 64)
 	if err != nil {
-		log.Error().Msgf("could not convert gid %s into an int")
+		log.Error().Msgf("could not convert gid %s into a uint64", u.Gid)
 		return nil, err
 	}
 
 	return &User{
 		Username: u.Username,
-		Uid:      uint64(uid),
-		Gid:      uint64(gid),
+		Uid:      uid,
+		Gid:      gid,
 		Dir:      u.HomeDir,
 		Shell:    "/bin/sh",
 	}, nil


### PR DESCRIPTION
# Background

SSH3 can incorrectly store a user's UID as a GID instead. This PR fixes that bug.

The responsible line is `gid, err := strconv.Atoi(u.Uid)`.

# Changes

- Fix the bug by reading from `u.Gid` instead.
- Use the correct number of arguments in nearby error messages.
- Use `strconv.ParseUint` instead to reduce the number of type conversions.

# Tests
- `go vet ./...` and `go test ./...` pass.