### PR TITLE
server: use sync.Map for managing running sessions

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -311,3 +311,22 @@ func DumpCertAndKeyToFiles(cert *x509.Certificate, pubkey crypto.PublicKey, priv
 
 	return nil
 }
+
+type SyncMap[K comparable, V any] struct {
+	inner sync.Map
+}
+
+func NewSyncMap[K comparable, V any]() SyncMap[K, V] {
+	return SyncMap[K, V]{
+		inner: sync.Map{},
+	}
+}
+
+func (m *SyncMap[K, V]) Get(key K) (V, bool) {
+	val, ok := m.inner.Load(key)
+	return val.(V), ok
+}
+
+func (m *SyncMap[K, V]) Insert(key K, val V) {
+	m.inner.Store(key, val)
+}


### PR DESCRIPTION
Until now, the server used a classical go map for handling sessions that could lead to undefined behaviour (cf #80).

This PR fixes that by using a the `sync.Map` standard type. 