### PR TITLE
add proper version negotiation

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -362,7 +362,7 @@ func Dial(ctx context.Context, options *Options, qconn quic.EarlyConnection,
 		return nil, err
 	}
 
-	log.Debug().Msgf("send CONNECT request to the server")
+	log.Debug().Msgf("establish conversation with the server")
 	err = conv.EstablishClientConversation(req, roundTripper, ssh3.AVAILABLE_CLIENT_VERSIONS)
 	if errors.Is(err, util.Unauthorized{}) {
 		log.Error().Msgf("Access denied from the server: unauthorized")

--- a/client/client.go
+++ b/client/client.go
@@ -268,7 +268,6 @@ func Dial(ctx context.Context, options *Options, qconn quic.EarlyConnection,
 		log.Fatal().Msgf("%s", err)
 	}
 	req.Proto = "ssh3"
-	req.Header.Set("User-Agent", ssh3.GetCurrentVersionString())
 
 	var identity ssh3.Identity
 	for _, method := range options.authMethods {
@@ -364,7 +363,7 @@ func Dial(ctx context.Context, options *Options, qconn quic.EarlyConnection,
 	}
 
 	log.Debug().Msgf("send CONNECT request to the server")
-	err = conv.EstablishClientConversation(req, roundTripper)
+	err = conv.EstablishClientConversation(req, roundTripper, ssh3.AVAILABLE_CLIENT_VERSIONS)
 	if errors.Is(err, util.Unauthorized{}) {
 		log.Error().Msgf("Access denied from the server: unauthorized")
 		return nil, err

--- a/cmd/ssh3/main.go
+++ b/cmd/ssh3/main.go
@@ -568,7 +568,7 @@ func mainWithStatusCode() int {
 
 		if qconn == nil {
 			if status != 0 {
-				log.Error().Msgf("could not setup transport for proxy client: %s", err)
+				log.Error().Msgf("could not setup transport for proxy client.")
 			}
 			return status
 		}

--- a/conversation.go
+++ b/conversation.go
@@ -163,7 +163,8 @@ func (c *Conversation) EstablishClientConversation(req *http.Request, roundTripp
 		}
 		if matchingVersionIndex != -1 {
 			log.Warn().Msgf("The server runs an old version of the protocol (%s). This software is still experimental, "+
-				"you may want to update the server version before support is removed.", serverVersion.GetVersionString())
+				"you may want to update the server version before support is removed. Also, note that connecting to old "+
+				"servers may increase the connection establishment time.", serverVersion.GetVersionString())
 			// now retry the request with the compatible version
 			rsp, serverVersion, err = doReq(supportedVersions[matchingVersionIndex], req)
 			if err != nil {

--- a/conversation.go
+++ b/conversation.go
@@ -141,9 +141,9 @@ func (c *Conversation) EstablishClientConversation(req *http.Request, roundTripp
 		return err
 	}
 
-	peerProtocolVersion := serverVersion.GetProtocolVersion()
+	serverProtocolVersion := serverVersion.GetProtocolVersion()
 	thisProtocolVersion := ThisVersion().GetProtocolVersion()
-	if rsp.StatusCode == http.StatusForbidden && peerProtocolVersion != thisProtocolVersion {
+	if rsp.StatusCode == http.StatusForbidden && serverProtocolVersion != thisProtocolVersion {
 		// This version negotiation code might feel a bit heavy but is only there for a smooth transition
 		// between early versions and versions coming from an actual IETF specification that include
 		// proper version negotiation. Older version of this implementation strictly check the exact protocol
@@ -158,7 +158,7 @@ func (c *Conversation) EstablishClientConversation(req *http.Request, roundTripp
 		// protocol version may still match
 		if matchingVersionIndex == -1 {
 			matchingVersionIndex = slices.IndexFunc(supportedVersions, func(supportedVersion Version) bool {
-				return peerProtocolVersion == thisProtocolVersion
+				return serverProtocolVersion == supportedVersion.GetProtocolVersion()
 			})
 		}
 		if matchingVersionIndex != -1 {

--- a/conversation.go
+++ b/conversation.go
@@ -113,7 +113,7 @@ func (c *Conversation) EstablishClientConversation(req *http.Request, roundTripp
 	}
 
 	doReq := func(version Version, req *http.Request) (*http.Response, Version, error) {
-		req.Header.Set("User-Agent", ThisVersion().GetVersionString())
+		req.Header.Set("User-Agent", version.GetVersionString())
 		log.Debug().Msgf("send %s request on URL %s, User-Agent=\"%s\"", req.Method, req.URL, req.Header.Get("User-Agent"))
 		rsp, err := roundTripper.RoundTripOpt(req, http3.RoundTripOpt{DontCloseRequestStream: true})
 		if err != nil {

--- a/conversation.go
+++ b/conversation.go
@@ -156,7 +156,7 @@ func (c *Conversation) EstablishClientConversation(req *http.Request, roundTripp
 
 		// there is no exact match, the implementation/software version might differ, but the
 		// protocol version may still match
-		if matchingVersionIndex != -1 {
+		if matchingVersionIndex == -1 {
 			matchingVersionIndex = slices.IndexFunc(supportedVersions, func(supportedVersion Version) bool {
 				return peerProtocolVersion == thisProtocolVersion
 			})

--- a/conversation.go
+++ b/conversation.go
@@ -131,7 +131,7 @@ func (c *Conversation) EstablishClientConversation(req *http.Request, roundTripp
 			}
 		} else {
 			log.Debug().Msgf("server has valid version \"%s\" (protocol version = %s, software version = %s)",
-							 serverVersionStr, serverVersion.GetProtocolVersion(), serverVersion.GetSoftwareVersion())
+				serverVersionStr, serverVersion.GetProtocolVersion(), serverVersion.GetSoftwareVersion())
 		}
 		return rsp, serverVersion, nil
 	}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/quic-go/quic-go v0.40.1-0.20240102075208-1083d1fb8f98
 	github.com/rs/zerolog v1.31.0
 	golang.org/x/crypto v0.17.0
+	golang.org/x/exp v0.0.0-20221205204356-47842c84f3db
 	golang.org/x/oauth2 v0.13.0
 	golang.org/x/term v0.15.0
 )
@@ -26,7 +27,6 @@ require (
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/quic-go/qpack v0.4.0 // indirect
 	go.uber.org/mock v0.3.0 // indirect
-	golang.org/x/exp v0.0.0-20221205204356-47842c84f3db // indirect
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect

--- a/integration_tests/ssh3_test.go
+++ b/integration_tests/ssh3_test.go
@@ -23,7 +23,7 @@ const DEFAULT_URL_PATH = "/ssh3-tests"
 const DEFAULT_PROXY_URL_PATH = "/ssh3-tests-proxy"
 
 var serverCommand *exec.Cmd
-var serverSessions map[string]*Session = make(map[string]*Session)	// bind address to session
+var serverSessions map[string]*Session = make(map[string]*Session) // bind address to session
 var proxyServerCommand *exec.Cmd
 var proxyServerSession *Session
 var rsaPrivKeyPath string
@@ -34,7 +34,7 @@ var username string
 const serverBind = "127.0.0.1:4433"
 const proxyServerBind = "127.0.0.1:4444"
 
-var oldServerBinds map[string]string = map[string]string {
+var oldServerBinds map[string]string = map[string]string{
 	"v0.1.5-rc1": "127.0.0.1:5000",
 	"v0.1.5-rc5": "127.0.0.1:5001",
 } // tag version to bind string
@@ -190,7 +190,7 @@ var _ = Describe("Testing the ssh3 cli", func() {
 				})
 
 				for key, val := range oldServerBinds {
-					// actually capture the values of key,val, as directly referring them in the code below will only keep the value of the last iteration 
+					// actually capture the values of key,val, as directly referring them in the code below will only keep the value of the last iteration
 					tag, bind := key, val
 					When("server version is"+tag+", bind is"+bind, func() {
 						It("Should connect using an RSA privkey to old supported server", func() {

--- a/unix_server/auth.go
+++ b/unix_server/auth.go
@@ -24,6 +24,7 @@ func HandleAuths(ctx context.Context, enablePasswordLogin bool, defaultMaxPacket
 		w.Header().Set("Server", ssh3.GetCurrentVersionString())
 		peerVersion, err := ssh3.ParseVersionString(r.UserAgent())
 		log.Debug().Msgf("received request from User-Agent %s", r.UserAgent())
+		log.Debug().Msgf("peer version: protocol version %s, software version %s", peerVersion.GetProtocolVersion(), peerVersion.GetSoftwareVersion())
 		// currently apply strict version rules
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Unsupported user-agent: %s", r.UserAgent()[:100]), http.StatusForbidden)

--- a/unix_server/auth.go
+++ b/unix_server/auth.go
@@ -53,7 +53,7 @@ func HandleAuths(ctx context.Context, enablePasswordLogin bool, defaultMaxPacket
 			return
 		}
 		str := r.Body.(http3.HTTPStreamer).HTTPStream()
-		conv, err := ssh3.NewServerConversation(ctx, str, qconn, qconn, defaultMaxPacketSize, *peerVersion)
+		conv, err := ssh3.NewServerConversation(ctx, str, qconn, qconn, defaultMaxPacketSize, peerVersion)
 		if err != nil {
 			log.Error().Msgf("could not create new server conversation")
 			w.WriteHeader(http.StatusInternalServerError)

--- a/version.go
+++ b/version.go
@@ -8,10 +8,186 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-const MAJOR int = 0
-const MINOR int = 1
-const PATCH int = 5
-const RC int = 5
+// EXPERIMENTAL_SPEC_VERSION specifies which version of the protocol this software
+// is implementing.
+// The protocol version string format is:
+//
+//	major + "." + minor[ + "_" + additional-version-information].
+//
+// It currently implements a first early version with no specification (alpha).
+// Once IETF drafts get published, we plan on having versions such as
+// 3.0_draft-michel-ssh3-XX when implementing the IETF specification from
+// draft-michel-ssh3-XX.
+const PROTOCOL_MAJOR int = 3
+const PROTOCOL_MINOR int = 0
+const PROTOCOL_EXPERIMENTAL_SPEC_VERSION string = "alpha-00"
+
+const SOFTWARE_IMPLEMENTATION_NAME string = "francoismichel/ssh3"
+const SOFTWARE_MAJOR int = 0
+const SOFTWARE_MINOR int = 1
+const SOFTWARE_PATCH int = 5
+
+const SOFTWARE_RC int = 5
+
+func ThisVersion() Version {
+	return Version{
+		protocolName: "SSH",
+		protocolVersion: ProtocolVersion{
+			Major:                   PROTOCOL_MAJOR,
+			Minor:                   PROTOCOL_MINOR,
+			ExperimentalSpecVersion: PROTOCOL_EXPERIMENTAL_SPEC_VERSION,
+		},
+		softwareVersion: SoftwareVersion{
+			Major: SOFTWARE_MAJOR,
+			Minor: SOFTWARE_MINOR,
+			Patch: SOFTWARE_PATCH,
+		},
+	}
+}
+
+// Tells if the this version (a.k.a. the version returned by ThisVersion())
+// is compatible with `other`.
+func IsVersionSupported(other *Version) bool {
+	this := ThisVersion()
+	// right now, no check for protocol name as it is subject to change
+
+	// strict protocol version checking
+	if other.protocolVersion.Major != this.protocolVersion.Major || other.protocolVersion.Minor != this.protocolVersion.Minor {
+		return false
+	}
+
+	// special case: to our knowledge, experimental spec version older than alpha-00 are only implemented by us (i.e. francoismichel/ssh3)
+	if other.protocolVersion.ExperimentalSpecVersion == "" && other.softwareVersion.ImplementationName == SOFTWARE_IMPLEMENTATION_NAME &&
+		other.softwareVersion.Major == 0 && other.softwareVersion.Minor == 1 && other.softwareVersion.Patch <= 5 {
+		// then, only support software version >= 0.1.4
+		return other.softwareVersion.Patch >= 4
+	}
+
+	// Starting from here, we have proper experimental spec version signalling.
+	// this version is version alpha-00, other versions are not supported.
+	// If a server receives a request with an unsupported spec version, the client should
+	// start a new request with a compatible version.
+	return other.protocolVersion.ExperimentalSpecVersion == "alpha-00"
+}
+
+type SoftwareVersion struct {
+	ImplementationName string
+	Major              int
+	Minor              int
+	Patch              int
+}
+
+type InvalidSoftwareVersion struct {
+	softwareVersionString string
+}
+
+func (e InvalidSoftwareVersion) Error() string {
+	return fmt.Sprintf("invalid protocol version string: %s", e.softwareVersionString)
+}
+
+func ParseSoftwareVersion(implementationName string, versionString string) (SoftwareVersion, error) {
+	majorDotMinor := strings.Split(versionString, ".")
+	if len(majorDotMinor) != 3 {
+		log.Error().Msgf("bad SSH version major.minor.patch field")
+		return SoftwareVersion{}, InvalidSoftwareVersion{softwareVersionString: versionString}
+	}
+	major, err := strconv.Atoi(majorDotMinor[0])
+	if err != nil {
+		log.Error().Msgf("bad software version major value")
+		return SoftwareVersion{}, InvalidSoftwareVersion{softwareVersionString: versionString}
+	}
+	minor, err := strconv.Atoi(majorDotMinor[1])
+	if err != nil {
+		log.Error().Msgf("bad software version minor value")
+		return SoftwareVersion{}, InvalidSoftwareVersion{softwareVersionString: versionString}
+	}
+	patch, err := strconv.Atoi(majorDotMinor[2])
+	if err != nil {
+		log.Error().Msgf("bad software version patch value")
+		return SoftwareVersion{}, InvalidSoftwareVersion{softwareVersionString: versionString}
+	}
+	return SoftwareVersion{
+		ImplementationName: implementationName,
+		Major:              major,
+		Minor:              minor,
+		Patch:              patch,
+	}, nil
+}
+
+func (v SoftwareVersion) String() string {
+	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+}
+
+type ProtocolVersion struct {
+	Major                   int
+	Minor                   int
+	ExperimentalSpecVersion string
+}
+
+func (v ProtocolVersion) String() string {
+	return fmt.Sprintf("%d.%d_%s", v.Major, v.Minor, v.ExperimentalSpecVersion)
+}
+
+type InvalidProtocolVersion struct {
+	protocolVersionString string
+}
+
+func (e InvalidProtocolVersion) Error() string {
+	return fmt.Sprintf("invalid protocol version string: %s", e.protocolVersionString)
+}
+
+func ParseProtocolVersion(versionString string) (ProtocolVersion, error) {
+	fields := strings.Split(versionString, "_")
+	if len(fields) == 0 || len(fields) > 2 {
+		return ProtocolVersion{}, InvalidProtocolVersion{protocolVersionString: versionString}
+	}
+	majorDotMinor := strings.Split(fields[0], ".")
+	if len(majorDotMinor) != 2 {
+		log.Error().Msgf("protocol version should be in format x.y, got: %s", fields[0])
+		return ProtocolVersion{}, InvalidProtocolVersion{protocolVersionString: versionString}
+	}
+	major, err := strconv.Atoi(majorDotMinor[0])
+	if err != nil {
+		log.Error().Msgf("bad protocol version major value %s: %s", majorDotMinor[0], err)
+		return ProtocolVersion{}, InvalidSSHVersion{versionString: versionString}
+	}
+	minor, err := strconv.Atoi(majorDotMinor[1])
+	if err != nil {
+		log.Error().Msgf("bad protocol version minor value %s: %s", majorDotMinor[1], err)
+		return ProtocolVersion{}, InvalidSSHVersion{versionString: versionString}
+	}
+	experimentalSpecVersion := ""
+	if len(fields) == 2 {
+		experimentalSpecVersion = fields[1]
+	}
+	return ProtocolVersion{
+		Major:                   major,
+		Minor:                   minor,
+		ExperimentalSpecVersion: experimentalSpecVersion,
+	}, nil
+}
+
+type Version struct {
+	protocolName    string // having the protocol name here might sound silly but there are discussions about updating the name right now and we want to support a change
+	protocolVersion ProtocolVersion
+	softwareVersion SoftwareVersion
+}
+
+func (v Version) GetProtocolVersion() ProtocolVersion {
+	return v.protocolVersion
+}
+
+func (v Version) GetSoftwareVersion() SoftwareVersion {
+	return v.softwareVersion
+}
+
+func NewVersion(protocolName string, protocolVersion ProtocolVersion, softwareVersion SoftwareVersion) *Version {
+	return &Version{
+		protocolName:    protocolName,
+		protocolVersion: protocolVersion,
+		softwareVersion: softwareVersion,
+	}
+}
 
 type InvalidSSHVersion struct {
 	versionString string
@@ -32,44 +208,53 @@ func (e UnsupportedSSHVersion) Error() string {
 // GetCurrentVersionString() returns the version string to be exchanged between two
 // endpoints for version negotiation
 func GetCurrentVersionString() string {
-	return fmt.Sprintf("SSH 3.0 francoismichel/ssh3 %d.%d.%d", MAJOR, MINOR, PATCH)
+	return fmt.Sprintf("SSH %d.%d %s %d.%d.%d experimental_spec_version=%s", PROTOCOL_MAJOR, PROTOCOL_MINOR, SOFTWARE_IMPLEMENTATION_NAME, SOFTWARE_MAJOR, SOFTWARE_MINOR, SOFTWARE_PATCH, PROTOCOL_EXPERIMENTAL_SPEC_VERSION)
 }
 
-func ParseVersionString(version string) (major int, minor int, patch int, err error) {
-	fields := strings.Fields(version)
-	if len(fields) < 4 || fields[0] != "SSH" || fields[1] != "3.0" {
+func ParseVersionString(versionString string) (version *Version, err error) {
+	fields := strings.Fields(versionString)
+	if len(fields) < 4 {
 		log.Error().Msgf("bad SSH version fields")
-		return 0, 0, 0, InvalidSSHVersion{versionString: version}
+		return nil, InvalidSSHVersion{versionString: versionString}
 	}
-	majorDotMinor := strings.Split(fields[3], ".")
-	if len(majorDotMinor) != 3 {
-		log.Error().Msgf("bad SSH version major.minor.patch field")
-		return 0, 0, 0, InvalidSSHVersion{versionString: version}
-	}
-	major, err = strconv.Atoi(majorDotMinor[0])
+	protocolName := fields[0]
+
+	protocolVersion, err := ParseProtocolVersion(fields[1])
 	if err != nil {
-		log.Error().Msgf("bad SSH version major value")
-		return 0, 0, 0, InvalidSSHVersion{versionString: version}
+		log.Error().Msgf("could not parse protocol version: %s", err)
+		return nil, err
 	}
-	minor, err = strconv.Atoi(majorDotMinor[1])
+
+	softwareVersion, err := ParseSoftwareVersion(fields[2], fields[3])
 	if err != nil {
-		log.Error().Msgf("bad SSH version minor value")
-		return 0, 0, 0, InvalidSSHVersion{versionString: version}
+		log.Error().Msgf("could not parse software version: %s", err)
+		return nil, err
 	}
-	patch, err = strconv.Atoi(majorDotMinor[2])
-	if err != nil {
-		log.Error().Msgf("bad SSH version patch value")
-		return 0, 0, 0, InvalidSSHVersion{versionString: version}
+
+	// Temporary tweak to announce a spec version while keeping compatibility with alpha-00 and older versions,
+	// as alpha-00 and older versions do strict version checking and error as soon as the protocol version is not "3.0".
+	// This will likely disappear once we decide to remove support for alpha-00 and older versions.
+	// From that point onwards, the spec version will be announced as part of the version field.
+	if len(fields) > 4 {
+		for _, field := range fields[4:] {
+			subfields := strings.Split(field, "=")
+			if len(subfields) == 2 && subfields[0] == "experimental_spec_version" {
+				protocolVersion.ExperimentalSpecVersion = subfields[1]
+			} else {
+				log.Debug().Msgf("skipping custom version field %s", field)
+			}
+		}
+
 	}
-	return major, minor, patch, nil
+	return NewVersion(protocolName, protocolVersion, softwareVersion), nil
 }
 
 // GetCurrentSoftwareVersion() returns the current software version to be displayed to the user
 // For version string to be communicated between endpoints, use GetCurrentVersionString() instead.
 func GetCurrentSoftwareVersion() string {
-	versionStr := fmt.Sprintf("%d.%d.%d", MAJOR, MINOR, PATCH)
-	if RC > 0 {
-		versionStr += fmt.Sprintf("-rc%d", RC)
+	versionStr := ThisVersion().softwareVersion.String()
+	if SOFTWARE_RC > 0 {
+		versionStr += fmt.Sprintf("-rc%d", SOFTWARE_RC)
 	}
 	return versionStr
 }

--- a/version.go
+++ b/version.go
@@ -65,9 +65,10 @@ func IsVersionSupported(other Version) bool {
 	}
 
 	// special case: to our knowledge, experimental spec version older than alpha-00 are only implemented by us (i.e. francoismichel/ssh3)
-	if other.protocolVersion.ExperimentalSpecVersion == "" && other.softwareVersion.ImplementationName == SOFTWARE_IMPLEMENTATION_NAME &&
+	// this should be removed in the near future, once we remove support for these legacy servers
+	if other.protocolVersion.ExperimentalSpecVersion == "" && other.softwareVersion.ImplementationName == "francoismichel/ssh3" &&
 		other.softwareVersion.Major == 0 && other.softwareVersion.Minor == 1 && other.softwareVersion.Patch <= 5 {
-		// then, only support software version >= 0.1.4
+		// then, only support software version >= 0.1.3
 		return other.softwareVersion.Patch >= 3
 	}
 

--- a/version.go
+++ b/version.go
@@ -33,6 +33,7 @@ var AVAILABLE_CLIENT_VERSIONS []Version = []Version{
 	ThisVersion(),
 	NewVersion("SSH", NewProtocolVersion(3, 0, ""), NewSoftwareVersion(0, 1, 5, SOFTWARE_IMPLEMENTATION_NAME)),
 	NewVersion("SSH", NewProtocolVersion(3, 0, ""), NewSoftwareVersion(0, 1, 4, SOFTWARE_IMPLEMENTATION_NAME)),
+	NewVersion("SSH", NewProtocolVersion(3, 0, ""), NewSoftwareVersion(0, 1, 3, SOFTWARE_IMPLEMENTATION_NAME)),
 }
 
 func ThisVersion() Version {
@@ -67,7 +68,7 @@ func IsVersionSupported(other Version) bool {
 	if other.protocolVersion.ExperimentalSpecVersion == "" && other.softwareVersion.ImplementationName == SOFTWARE_IMPLEMENTATION_NAME &&
 		other.softwareVersion.Major == 0 && other.softwareVersion.Minor == 1 && other.softwareVersion.Patch <= 5 {
 		// then, only support software version >= 0.1.4
-		return other.softwareVersion.Patch >= 4
+		return other.softwareVersion.Patch >= 3
 	}
 
 	// Starting from here, we have proper experimental spec version signalling.
@@ -149,7 +150,11 @@ func NewProtocolVersion(major int, minor int, experimentalspecversion string) Pr
 }
 
 func (v ProtocolVersion) String() string {
-	return fmt.Sprintf("%d.%d_%s", v.Major, v.Minor, v.ExperimentalSpecVersion)
+	ret := fmt.Sprintf("%d.%d", v.Major, v.Minor)
+	if v.ExperimentalSpecVersion != "" {
+		ret = fmt.Sprintf("%s_%s", ret, v.ExperimentalSpecVersion)
+	}
+	return ret
 }
 
 type InvalidProtocolVersion struct {


### PR DESCRIPTION
Until now, the version was strictly checked against the software version.

Now that the project gains in popularity and that a spec is coming, other people may try implementing the protocol.

This adds a version negotiation mechanism that is still quite strict.

* Add the concept of protocol *experimental spec version*, this currently implements the `alpha-00` experimental spec version.
* Do not check the *software* version during the negotiation, except for versions before `alpha-00`, where the implementation name then MUST be `francoismichel/ssh3`
* Right now, the server supports clients with version `alpha-00` and older, i.e. clients with implementation name `francoismichel/ssh3` and software version between `0.1.4` (included) and `0.1.5` (included)
* Future clients implementing future draft versions will have to adapt their version to the server version. If the server does not support the client version, the client has to retry a new connection with a version that matches the server's version. A message should be displayed to the user, ensuring that the user knows that they should update the server version. Such a message will disappear with stable versions of the protocol.