### PR TITLE
version 0.1.6-rc1

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ You can either download the last [release binaries](https://github.com/francoism
 
 ### Installing ssh3 and ssh3-server using Go install
 ```bash
-go install github.com/francoismichel/ssh3/cmd/...@v0.1.5-rc5
+go install github.com/francoismichel/ssh3/cmd/...@v0.1.6-rc1
 ```
 
 

--- a/version.go
+++ b/version.go
@@ -25,9 +25,9 @@ const PROTOCOL_EXPERIMENTAL_SPEC_VERSION string = "alpha-00"
 const SOFTWARE_IMPLEMENTATION_NAME string = "francoismichel/ssh3"
 const SOFTWARE_MAJOR int = 0
 const SOFTWARE_MINOR int = 1
-const SOFTWARE_PATCH int = 5
+const SOFTWARE_PATCH int = 6
 
-const SOFTWARE_RC int = 5
+const SOFTWARE_RC int = 1
 
 var AVAILABLE_CLIENT_VERSIONS []Version = []Version{
 	ThisVersion(),


### PR DESCRIPTION
Proper version negotiation was added when developing software version 0.1.5. Instead of creating a new 0.1.5-rc that has version negotiation, it will be easier to just release version 0.1.6. Doing that, we know that every release before 0.1.6 has not version negotiation support.