### PR TITLE
make generic SyncMap with with actually any type

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -335,6 +335,11 @@ func NewSyncMap[K comparable, V any]() SyncMap[K, V] {
 
 func (m *SyncMap[K, V]) Get(key K) (V, bool) {
 	val, ok := m.inner.Load(key)
+	if val == nil {
+		// we can't return nil for *any* type, so we create a zero value for the type and return it, instead of nil
+		var zero V
+		return zero, ok
+	}
 	return val.(V), ok
 }
 


### PR DESCRIPTION
The `SyncMap` genreic type does not work with non-nilable types, as the `nil` value returned by `sync.Map` cannot be converted to the `V` generic type. Replace nil by the zero value if that's the case.