### PR TITLE
better handle unknown identities

### DIFF
--- a/unix_server/authorized_identities.go
+++ b/unix_server/authorized_identities.go
@@ -136,6 +136,9 @@ func ParseIdentity(user *unix_util.User, identityStr string) (Identity, error) {
 			log.Debug().Msgf("parsing %s identity", out.Type())
 			cryptoPublicKey := out.(ssh.CryptoPublicKey)
 			return &PubKeyIdentity{username: user.Username, pubkey: cryptoPublicKey.CryptoPublicKey()}, nil
+
+		default:
+			return nil, fmt.Errorf("SSH authorized identity \"%s\" not implemented", out.Type())
 		}
 	}
 	// it is not an SSH key


### PR DESCRIPTION
Until now, the server panics upon an unknown identity in the authorized_identities/authorized_keys files. While this does not stop the server, this PR returns an error instead of panicking, which is cleaner.