### PR TITLE
do not use dual-stack UDP sockets on MacOS to enable MTU discovery

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -382,7 +382,7 @@ func (c *Client) ForwardUDP(ctx context.Context, localUDPAddr *net.UDPAddr, remo
 	log.Debug().Msgf("start UDP forwarding from %s to %s", localUDPAddr, remoteUDPAddr)
 	conn, err := net.ListenUDP("udp", localUDPAddr)
 	if err != nil {
-		log.Error().Msgf("could listen on UDP socket: %s", err)
+		log.Error().Msgf("could not listen on UDP socket: %s", err)
 		return nil, err
 	}
 	forwardings := make(map[string]ssh3.Channel)
@@ -391,7 +391,7 @@ func (c *Client) ForwardUDP(ctx context.Context, localUDPAddr *net.UDPAddr, remo
 		for {
 			n, addr, err := conn.ReadFromUDP(buf)
 			if err != nil {
-				log.Error().Msgf("could read on UDP socket: %s", err)
+				log.Error().Msgf("could not read on UDP socket: %s", err)
 				return
 			}
 			channel, ok := forwardings[addr.String()]


### PR DESCRIPTION
MacOS does not correctly set the DF bit on dual-stack UDP sockets (`udp` instead of `udp4` and `udp6`). This quic-go issue discusses that problem: https://github.com/quic-go/quic-go/issues/3793

without the DF bit set, quic-go won't perform path MTU discovery. Without path MTU discuvery, the default MTU will be too small to carry the quic-go initial packet (which could theoretically be 40 bytes smaller but quic-go fills the IP packet at maximum in its initial).

This PR fixes the problem on the client by not using a dual stack socket on MacOS.

The problem is not fixed on the MacOS server as servers often listen on dual-stack sockets.

Fixes #129 