### PR TITLE
OIDC: fix PKCE random verifier generation

### DIFF
--- a/auth/openid_connect.go
+++ b/auth/openid_connect.go
@@ -74,7 +74,7 @@ func Connect(ctx context.Context, oidcConfig *OIDCConfig, issuerURL string, doPK
 		return "", fmt.Errorf("error when generating random verifier: %s", err.Error())
 	}
 
-	verifier := string(challengeVerifierBytes[:])
+	verifier := oauth2.GenerateVerifier()
 
 	tokenChannel := make(chan string)
 	mux := http.NewServeMux()


### PR DESCRIPTION
fix a bug in the PKCE process of OpenID Connect. The generated verifier had an invalid format.